### PR TITLE
Add prometheus mode for kvdb tool

### DIFF
--- a/src/kvdb/mod.rs
+++ b/src/kvdb/mod.rs
@@ -115,7 +115,7 @@ pub(crate) enum KvdbMode {
 	DecodeKeys(KvdbKeysOpts),
 	/// Dump database (works with a live database for RocksDB)
 	Dump(KvdbDumpOpts),
-	/// Work as prometheus endpoint providing kvdb metrics
+	/// Same as Usage, exposing metrics via a Prometheus endpoint
 	Prometheus(KvdbPrometheusOptions),
 }
 
@@ -334,7 +334,7 @@ async fn run_with_db<D: IntrospectorKvdb + Sync + Send + 'static>(db: D, opts: K
 				Ok(futures) => {
 					future::try_join_all(futures).await.map_err(|e| eyre!("Join error: {:?}", e))?;
 				},
-				Err(err) => error!("FATAL: cannot start prometheus kvdb command: {}", err),
+				Err(err) => error!("FATAL: cannot start kvdb command in prometheus mode: {}", err),
 			}
 		},
 	}

--- a/src/kvdb/paritydb.rs
+++ b/src/kvdb/paritydb.rs
@@ -19,11 +19,13 @@
 use super::{DBIter, IntrospectorKvdb};
 use color_eyre::{eyre::eyre, Result};
 use parity_db::{Db, Options as ParityDBOptions};
+use std::path::{Path, PathBuf};
 
 pub struct IntrospectorParityDB {
 	inner: Db,
 	columns: Vec<String>,
 	read_only: bool,
+	path: PathBuf,
 }
 
 impl IntrospectorKvdb for IntrospectorParityDB {
@@ -40,7 +42,7 @@ impl IntrospectorKvdb for IntrospectorParityDB {
 			.enumerate()
 			.map(|(idx, _)| format!("col{}", idx))
 			.collect::<Vec<_>>();
-		Ok(Self { inner: db, columns, read_only: true })
+		Ok(Self { inner: db, columns, read_only: true, path: path.into() })
 	}
 
 	fn list_columns(&self) -> color_eyre::Result<&Vec<String>> {
@@ -87,6 +89,10 @@ impl IntrospectorKvdb for IntrospectorParityDB {
 		self.read_only
 	}
 
+	fn get_db_path(&self) -> &Path {
+		self.path.as_path()
+	}
+
 	fn write_iter<I, K, V>(&self, column: &str, iter: I) -> Result<()>
 	where
 		I: IntoIterator<Item = (K, V)>,
@@ -117,7 +123,7 @@ impl IntrospectorKvdb for IntrospectorParityDB {
 		}
 
 		let db = Db::open_or_create(&opts)?;
-		Ok(IntrospectorParityDB { inner: db, columns, read_only: false })
+		Ok(IntrospectorParityDB { inner: db, columns, read_only: false, path: output_path.into() })
 	}
 }
 
@@ -136,6 +142,6 @@ pub(crate) mod tests {
 		}
 
 		let db = Db::open_or_create(&opts).unwrap();
-		IntrospectorParityDB { inner: db, columns, read_only: false }
+		IntrospectorParityDB { inner: db, columns, read_only: false, path: output_path.into() }
 	}
 }

--- a/src/kvdb/prometheus.rs
+++ b/src/kvdb/prometheus.rs
@@ -156,6 +156,9 @@ fn register_metrics(registry: &Registry) -> KvdbPrometheusMetrics {
 fn maybe_reopen_db<D: IntrospectorKvdb>(db: D) -> D {
 	match D::new(db.get_db_path()) {
 		Ok(new_db) => new_db,
-		Err(_) => db,
+		Err(e) => {
+			error!("Cannot reopen database at {:?}: {:?}", db.get_db_path(), e);
+			db
+		},
 	}
 }

--- a/src/kvdb/prometheus.rs
+++ b/src/kvdb/prometheus.rs
@@ -1,0 +1,135 @@
+// Copyright 2022 Parity Technologies (UK) Ltd.
+// This file is part of polkadot-introspector.
+//
+// polkadot-introspector is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// polkadot-introspector is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::kvdb::IntrospectorKvdb;
+use clap::Parser;
+use color_eyre::Result;
+use log::info;
+use prometheus_endpoint::{prometheus::IntGaugeVec, Opts, Registry};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+#[derive(Clone, Debug, Parser, Default)]
+#[clap(rename_all = "kebab-case")]
+pub struct KvdbPrometheusOptions {
+	/// Prometheus endpoint port.
+	#[clap(long, default_value = "65432")]
+	port: u16,
+	/// Database poll timeout (default, once per 5 minutes).
+	#[clap(long, default_value = "300.0")]
+	poll_timeout: f32,
+}
+
+struct KvdbPrometheusMetrics {
+	keys_size_gauge: IntGaugeVec,
+	values_size_gauge: IntGaugeVec,
+	elements_count_gauge: IntGaugeVec,
+}
+
+pub async fn run_prometheus_endpoint_with_db<D: IntrospectorKvdb + Send + Sync + 'static>(
+	db: D,
+	prometheus_opts: KvdbPrometheusOptions,
+) -> Result<Vec<tokio::task::JoinHandle<()>>> {
+	let prometheus_registry = Registry::new_custom(Some("introspector".into()), None)?;
+	let metrics = Arc::new(Mutex::new(register_metrics(&prometheus_registry)));
+	let socket_addr =
+		std::net::SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)), prometheus_opts.port);
+	let mut futures: Vec<tokio::task::JoinHandle<()>> = vec![];
+	futures.push(tokio::spawn(async move {
+		prometheus_endpoint::init_prometheus(socket_addr, prometheus_registry)
+			.await
+			.unwrap()
+	}));
+	futures.push(tokio::spawn(async move {
+		update_db(db, metrics.clone(), prometheus_opts).await;
+	}));
+	info!("Starting prometheus node on {:?}", socket_addr);
+
+	Ok(futures)
+}
+
+struct UpdateResult {
+	column: String,
+	keys_count: i64,
+	keys_space: i64,
+	values_space: i64,
+}
+
+async fn update_db<D: IntrospectorKvdb>(
+	db: D,
+	metrics: Arc<Mutex<KvdbPrometheusMetrics>>,
+	prometheus_opts: KvdbPrometheusOptions,
+) {
+	loop {
+		info!("Starting update db iteration");
+		let columns = db.list_columns().unwrap();
+		let mut update_results: Vec<UpdateResult> = vec![];
+		for col in columns {
+			let mut keys_space = 0_i64;
+			let mut keys_count = 0_i64;
+			let mut values_space = 0_i64;
+
+			info!("Iterating over column {}", col.as_str());
+			let iter = db.iter_values(col.as_str()).unwrap();
+			for (key, value) in iter {
+				keys_space += key.len() as i64;
+				keys_count += 1;
+				values_space += value.len() as i64;
+			}
+
+			update_results.push(UpdateResult { column: col.clone(), keys_count, keys_space, values_space });
+		}
+
+		let unlocked_metrics = metrics.lock().await;
+
+		for res in &update_results {
+			unlocked_metrics
+				.elements_count_gauge
+				.with_label_values(&[res.column.as_str()])
+				.set(res.keys_count);
+			unlocked_metrics
+				.keys_size_gauge
+				.with_label_values(&[res.column.as_str()])
+				.set(res.keys_space);
+			unlocked_metrics
+				.values_size_gauge
+				.with_label_values(&[res.column.as_str()])
+				.set(res.values_space);
+		}
+		info!("Ended update db iteration");
+		tokio::time::sleep(std::time::Duration::from_secs_f32(prometheus_opts.poll_timeout)).await;
+	}
+}
+
+fn register_metrics(registry: &Registry) -> KvdbPrometheusMetrics {
+	let elements_count_gauge = prometheus_endpoint::register(
+		IntGaugeVec::new(Opts::new("kvdb_elements_count", "Number of keys in kvdb"), &["column"]).unwrap(),
+		registry,
+	)
+	.expect("Failed to register metric");
+	let keys_size_gauge = prometheus_endpoint::register(
+		IntGaugeVec::new(Opts::new("kvdb_keys_size", "Size of keys in KVDB"), &["column"]).unwrap(),
+		registry,
+	)
+	.expect("Failed to register metric");
+	let values_size_gauge = prometheus_endpoint::register(
+		IntGaugeVec::new(Opts::new("kvdb_values_size", "Size of keys in KVDB"), &["column"]).unwrap(),
+		registry,
+	)
+	.expect("Failed to register metric");
+
+	KvdbPrometheusMetrics { keys_size_gauge, values_size_gauge, elements_count_gauge }
+}

--- a/src/kvdb/traits.rs
+++ b/src/kvdb/traits.rs
@@ -33,6 +33,8 @@ pub trait IntrospectorKvdb {
 	fn read_only(&self) -> bool {
 		true
 	}
+	/// Returns a path to database
+	fn get_db_path(&self) -> &std::path::Path;
 	/// Writes an iterator of columns/keys/values to the kvdb  (kvdb must be not in the read-only mode)
 	fn write_iter<I, K, V>(&self, column: &str, iter: I) -> Result<()>
 	where

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ async fn main() -> color_eyre::Result<()> {
 			}
 		},
 		Command::Kvdb(opts) => {
-			kvdb::introspect_kvdb(opts)?;
+			kvdb::introspect_kvdb(opts).await?;
 		},
 		Command::ParachainCommander(opts) => {
 			let mut core = core::SubxtWrapper::new(vec![opts.node.clone()]);


### PR DESCRIPTION
This PR adds `prometheus` mode for kvdb, allowing to monitor database usage from Prometheus:

```
curl 'http://localhost:65432/metrics'
# HELP introspector_kvdb_elements_count Number of keys in kvdb
# TYPE introspector_kvdb_elements_count gauge
introspector_kvdb_elements_count{column="col0"} 1173995
introspector_kvdb_elements_count{column="col1"} 389466
introspector_kvdb_elements_count{column="col2"} 79
introspector_kvdb_elements_count{column="col3"} 15001
introspector_kvdb_elements_count{column="col4"} 10991
# HELP introspector_kvdb_keys_size Size of keys in KVDB
# TYPE introspector_kvdb_keys_size gauge
introspector_kvdb_keys_size{column="col0"} 48133795
introspector_kvdb_keys_size{column="col1"} 17334135
introspector_kvdb_keys_size{column="col2"} 3490
introspector_kvdb_keys_size{column="col3"} 330117
introspector_kvdb_keys_size{column="col4"} 560478
# HELP introspector_kvdb_values_size Size of keys in KVDB
# TYPE introspector_kvdb_values_size gauge
introspector_kvdb_values_size{column="col0"} 1445411701
introspector_kvdb_values_size{column="col1"} 9155436
introspector_kvdb_values_size{column="col2"} 125782
introspector_kvdb_values_size{column="col3"} 633760
introspector_kvdb_values_size{column="col4"} 52112606
```