### PR TITLE
Implement prefixed and generic storage

### DIFF
--- a/src/block_time/mod.rs
+++ b/src/block_time/mod.rs
@@ -29,6 +29,7 @@ use std::{
 	io::{stdout, Write},
 	sync::{Arc, Mutex},
 };
+use subxt::sp_core::H256;
 use tokio::sync::mpsc::Receiver;
 
 #[derive(Clone, Debug, Parser)]
@@ -75,7 +76,7 @@ pub(crate) struct BlockTimeMonitor {
 	block_time_metric: Option<HistogramVec>,
 	endpoints: Vec<String>,
 	consumer_config: EventConsumerInit<SubxtEvent>,
-	api_service: ApiService,
+	api_service: ApiService<H256>,
 }
 
 impl BlockTimeMonitor {
@@ -198,7 +199,7 @@ impl BlockTimeMonitor {
 		values: Arc<Mutex<VecDeque<u64>>>,
 		// TODO: make this a struct.
 		mut consumer_config: Receiver<SubxtEvent>,
-		api_service: ApiService,
+		api_service: ApiService<H256>,
 	) {
 		// Make static string out of uri so we can use it as Prometheus label.
 		let url = leak_static_str(url);
@@ -269,7 +270,7 @@ async fn populate_view(
 	values: Arc<Mutex<VecDeque<u64>>>,
 	url: &str,
 	cli_opts: BlockTimeCliOptions,
-	api_service: ApiService,
+	api_service: ApiService<H256>,
 ) {
 	let mut prev_ts = 0u64;
 	let blocks_to_fetch = cli_opts.chart_width;

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -130,7 +130,7 @@ pub(crate) async fn run(
 	consumer_config: EventConsumerInit<SubxtEvent>,
 ) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>> {
 	let api_service =
-		ApiService::new_with_storage(RecordsStorageConfig { max_blocks: opts.max_blocks.unwrap_or(1000) });
+		ApiService::new_with_prefixed_storage(RecordsStorageConfig { max_blocks: opts.max_blocks.unwrap_or(1000) });
 	let (shutdown_tx, shutdown_rx) = broadcast::channel(1);
 	let (to_websocket, _) = broadcast::channel(32);
 	let endpoints = opts.nodes.clone().into_iter();

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -130,7 +130,7 @@ pub(crate) async fn run(
 	Ok(futures)
 }
 
-async fn process_new_head(url: &str, api_service: &ApiService, block_hash: H256) -> color_eyre::Result<()> {
+async fn process_new_head(url: &str, api_service: &ApiService<H256>, block_hash: H256) -> color_eyre::Result<()> {
 	let executor = api_service.subxt();
 	let ts = executor.get_block_timestamp(url.into(), Some(block_hash)).await;
 	let header = executor
@@ -149,7 +149,7 @@ async fn process_new_head(url: &str, api_service: &ApiService, block_hash: H256)
 }
 
 async fn process_candidate_change(
-	api_service: &ApiService,
+	api_service: &ApiService<H256>,
 	change_event: SubxtCandidateEvent,
 	to_websocket: &Sender<WebSocketUpdateEvent>,
 ) -> color_eyre::Result<()> {
@@ -274,7 +274,7 @@ async fn process_candidate_change(
 }
 
 async fn process_dispute_initiated(
-	api_service: &ApiService,
+	api_service: &ApiService<H256>,
 	dispute_event: SubxtDispute,
 	to_websocket: &Sender<WebSocketUpdateEvent>,
 ) -> color_eyre::Result<()> {
@@ -301,7 +301,7 @@ async fn process_dispute_initiated(
 }
 
 async fn process_dispute_concluded(
-	api_service: &ApiService,
+	api_service: &ApiService<H256>,
 	dispute_event: SubxtDispute,
 	dispute_outcome: SubxtDisputeResult,
 	to_websocket: &Sender<WebSocketUpdateEvent>,

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -32,8 +32,8 @@ mod candidate_record;
 mod ws;
 
 use crate::core::{
-	ApiService, EventConsumerInit, RecordTime, RecordsStorageConfig, StorageEntry, StorageInfo, SubxtCandidateEvent,
-	SubxtCandidateEventType, SubxtDispute, SubxtDisputeResult, SubxtEvent,
+	ApiService, EventConsumerInit, HasPrefix, RecordTime, RecordsStorageConfig, StorageEntry, StorageInfo,
+	SubxtCandidateEvent, SubxtCandidateEventType, SubxtDispute, SubxtDisputeResult, SubxtEvent,
 };
 use candidate_record::*;
 use color_eyre::eyre::eyre;
@@ -65,6 +65,12 @@ impl From<CollectorOptions> for WebSocketListenerConfig {
 pub(crate) struct CollectorKey {
 	pub prefix: String,
 	pub hash: Option<H256>,
+}
+
+impl HasPrefix for CollectorKey {
+	fn has_prefix(&self, prefix: &Self) -> bool {
+		self.prefix == prefix.prefix
+	}
 }
 
 pub(crate) const CANDIDATE_PREFIX: &str = "candidate";

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -102,8 +102,9 @@ impl HasPrefix for CollectorKey {
 			CollectorPrefixType::Head => other.prefix == self.prefix,
 			CollectorPrefixType::Candidate(maybe_para) => match other.prefix {
 				CollectorPrefixType::Head => false,
-				CollectorPrefixType::Candidate(maybe_other_para) =>
-					maybe_other_para.is_none() || maybe_para == maybe_other_para,
+				CollectorPrefixType::Candidate(maybe_other_para) => {
+					maybe_other_para.is_none() || maybe_para.is_none() || maybe_para == maybe_other_para
+				},
 			},
 		}
 	}
@@ -114,7 +115,7 @@ impl HasPrefix for CollectorKey {
 // a specific entry with no hash
 impl PartialEq for CollectorKey {
 	fn eq(&self, other: &Self) -> bool {
-		self.hash == other.hash && self.has_prefix(other)
+		self.hash == other.hash && (self.has_prefix(other) || other.has_prefix(self))
 	}
 }
 
@@ -289,7 +290,7 @@ async fn process_candidate_change(
 						"no stored relay parent {} for candidate {}",
 						change_event.candidate_descriptor.relay_parent,
 						change_event.candidate_hash
-					))
+					));
 				}
 			}
 		},

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -102,9 +102,8 @@ impl HasPrefix for CollectorKey {
 			CollectorPrefixType::Head => other.prefix == self.prefix,
 			CollectorPrefixType::Candidate(maybe_para) => match other.prefix {
 				CollectorPrefixType::Head => false,
-				CollectorPrefixType::Candidate(maybe_other_para) => {
-					maybe_other_para.is_none() || maybe_para.is_none() || maybe_para == maybe_other_para
-				},
+				CollectorPrefixType::Candidate(maybe_other_para) =>
+					maybe_other_para.is_none() || maybe_para.is_none() || maybe_para == maybe_other_para,
 			},
 		}
 	}
@@ -290,7 +289,7 @@ async fn process_candidate_change(
 						"no stored relay parent {} for candidate {}",
 						change_event.candidate_descriptor.relay_parent,
 						change_event.candidate_hash
-					));
+					))
 				}
 			}
 		},

--- a/src/collector/ws.rs
+++ b/src/collector/ws.rs
@@ -223,7 +223,7 @@ async fn candidates_handler(
 ) -> Result<impl Reply, Rejection> {
 	let keys = api
 		.storage()
-		.storage_keys(Some(CollectorKey { prefix: CANDIDATE_PREFIX.into(), hash: None }))
+		.storage_keys_prefix(CollectorKey::new_with_prefix(CANDIDATE_PREFIX))
 		.await;
 	// TODO: add filters support somehow...
 
@@ -242,7 +242,7 @@ async fn candidate_get_handler(
 ) -> Result<impl Reply, Rejection> {
 	let candidate_record = api
 		.storage()
-		.storage_read(CollectorKey { prefix: CANDIDATE_PREFIX.into(), hash: Some(candidate_hash.hash) })
+		.storage_read(CollectorKey::new_with_hash(CANDIDATE_PREFIX, candidate_hash.hash))
 		.await;
 
 	match candidate_record {

--- a/src/collector/ws.rs
+++ b/src/collector/ws.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 use crate::{
-	collector::{candidate_record::CandidateRecord, CollectorKey, CANDIDATE_PREFIX},
+	collector::{candidate_record::CandidateRecord, CollectorKey, CollectorKeyPrefix},
 	core::{api::ApiService, SubxtDisputeResult},
 };
 use futures::{SinkExt, StreamExt};
@@ -223,7 +223,7 @@ async fn candidates_handler(
 ) -> Result<impl Reply, Rejection> {
 	let keys = api
 		.storage()
-		.storage_keys_prefix(CollectorKey::new_with_prefix(CANDIDATE_PREFIX))
+		.storage_keys_prefix(CollectorKey::new_with_prefix(CollectorKeyPrefix::Candidate))
 		.await;
 	// TODO: add filters support somehow...
 
@@ -242,7 +242,7 @@ async fn candidate_get_handler(
 ) -> Result<impl Reply, Rejection> {
 	let candidate_record = api
 		.storage()
-		.storage_read(CollectorKey::new_with_hash(CANDIDATE_PREFIX, candidate_hash.hash))
+		.storage_read(CollectorKey::new_with_hash(CollectorKeyPrefix::Candidate, candidate_hash.hash))
 		.await;
 
 	match candidate_record {

--- a/src/core/api/mod.rs
+++ b/src/core/api/mod.rs
@@ -16,7 +16,7 @@
 //
 #![allow(dead_code)]
 
-use crate::core::{RecordsStorageConfig, MAX_MSG_QUEUE_SIZE};
+use crate::core::{HasPrefix, RecordsStorageConfig, MAX_MSG_QUEUE_SIZE};
 use std::{fmt::Debug, hash::Hash};
 use tokio::sync::mpsc::{channel, Sender};
 
@@ -27,14 +27,14 @@ pub use subxt_wrapper::*;
 
 // Provides access to subxt and storage APIs, more to come.
 #[derive(Clone)]
-pub struct ApiService<K: Ord + Hash> {
+pub struct ApiService<K: Ord + Hash + HasPrefix> {
 	subxt_tx: Sender<subxt_wrapper::Request>,
 	storage_tx: Sender<storage::Request<K>>,
 }
 
 impl<K> ApiService<K>
 where
-	K: Ord + Sized + Hash + Debug + Clone + Send + 'static,
+	K: Ord + Sized + Hash + Debug + Clone + Send + 'static + HasPrefix,
 {
 	pub fn new_with_storage(storage_config: RecordsStorageConfig) -> ApiService<K> {
 		let (subxt_tx, subxt_rx) = channel(MAX_MSG_QUEUE_SIZE);

--- a/src/core/api/mod.rs
+++ b/src/core/api/mod.rs
@@ -27,14 +27,14 @@ pub use subxt_wrapper::*;
 
 // Provides access to subxt and storage APIs, more to come.
 #[derive(Clone)]
-pub struct ApiService<K: Ord + Hash + HasPrefix> {
+pub struct ApiService<K: Ord + Hash> {
 	subxt_tx: Sender<subxt_wrapper::Request>,
 	storage_tx: Sender<storage::Request<K>>,
 }
 
 impl<K> ApiService<K>
 where
-	K: Ord + Sized + Hash + Debug + Clone + Send + 'static + HasPrefix,
+	K: Ord + Sized + Hash + Debug + Clone + Send + 'static,
 {
 	pub fn new_with_storage(storage_config: RecordsStorageConfig) -> ApiService<K> {
 		let (subxt_tx, subxt_rx) = channel(MAX_MSG_QUEUE_SIZE);
@@ -55,6 +55,20 @@ where
 	}
 }
 
+impl<K> ApiService<K>
+where
+	K: Ord + Sized + Hash + Debug + Clone + Send + HasPrefix + 'static,
+{
+	pub fn new_with_prefixed_storage(storage_config: RecordsStorageConfig) -> ApiService<K> {
+		let (subxt_tx, subxt_rx) = channel(MAX_MSG_QUEUE_SIZE);
+		let (storage_tx, storage_rx) = channel(MAX_MSG_QUEUE_SIZE);
+
+		tokio::spawn(subxt_wrapper::api_handler_task(subxt_rx));
+		tokio::spawn(storage::api_handler_task_prefixed(storage_rx, storage_config));
+
+		Self { subxt_tx, storage_tx }
+	}
+}
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/src/core/api/storage.rs
+++ b/src/core/api/storage.rs
@@ -129,7 +129,7 @@ impl<K: Ord + Hash + Sized + Debug> RequestExecutor<K> {
 	}
 }
 
-// A task that handles storage API calls.
+/// Creates a task that handles storage API calls (generic version with no prefixes support).
 pub(crate) async fn api_handler_task<K>(mut api: Receiver<Request<K>>, storage_config: RecordsStorageConfig)
 where
 	K: Ord + Sized + Hash + Debug + Clone,
@@ -184,6 +184,7 @@ where
 	}
 }
 
+/// Creates the API handler with prefixes support. `K` must has `HasPrefix` trait
 pub(crate) async fn api_handler_task_prefixed<K>(mut api: Receiver<Request<K>>, storage_config: RecordsStorageConfig)
 where
 	K: Ord + Sized + Hash + Debug + Clone + HasPrefix,

--- a/src/core/api/storage.rs
+++ b/src/core/api/storage.rs
@@ -28,7 +28,7 @@ use tokio::sync::{
 
 // Storage requests
 #[derive(Clone, Debug)]
-pub enum RequestType<K: Ord + Hash + Sized + HasPrefix> {
+pub enum RequestType<K: Ord + Hash + Sized> {
 	Write(K, StorageEntry),
 	Read(K),
 	Replace(K, StorageEntry),
@@ -38,23 +38,23 @@ pub enum RequestType<K: Ord + Hash + Sized + HasPrefix> {
 }
 
 #[derive(Debug)]
-pub struct Request<K: Ord + Hash + Sized + HasPrefix> {
+pub struct Request<K: Ord + Hash + Sized> {
 	pub request_type: RequestType<K>,
 	pub response_sender: Option<oneshot::Sender<Response<K>>>,
 }
 
 #[derive(Debug)]
-pub enum Response<K: Ord + Hash + Sized + HasPrefix> {
+pub enum Response<K: Ord + Hash + Sized> {
 	StorageReadResponse(Option<StorageEntry>),
 	StorageSizeResponse(usize),
 	StorageKeysResponse(Vec<K>),
 	StorageStatusResponse(color_eyre::Result<()>),
 }
-pub struct RequestExecutor<K: Ord + Hash + Sized + HasPrefix> {
+pub struct RequestExecutor<K: Ord + Hash + Sized> {
 	to_api: Sender<Request<K>>,
 }
 
-impl<K: Ord + Hash + Sized + Debug + HasPrefix> RequestExecutor<K> {
+impl<K: Ord + Hash + Sized + Debug> RequestExecutor<K> {
 	pub fn new(to_api: Sender<Request<K>>) -> Self {
 		RequestExecutor { to_api }
 	}
@@ -130,10 +130,64 @@ impl<K: Ord + Hash + Sized + Debug + HasPrefix> RequestExecutor<K> {
 }
 
 // A task that handles storage API calls.
-pub(crate) async fn api_handler_task<K: Ord + Sized + Hash + Debug + Clone + HasPrefix>(
-	mut api: Receiver<Request<K>>,
-	storage_config: RecordsStorageConfig,
-) {
+pub(crate) async fn api_handler_task<K>(mut api: Receiver<Request<K>>, storage_config: RecordsStorageConfig)
+where
+	K: Ord + Sized + Hash + Debug + Clone,
+{
+	// The storage lives here.
+	let mut the_storage = RecordsStorage::new(storage_config);
+
+	while let Some(request) = api.recv().await {
+		match request.request_type {
+			RequestType::Read(key) => {
+				request
+					.response_sender
+					.expect("no sender provided")
+					.send(Response::StorageReadResponse(the_storage.get(&key)))
+					.unwrap();
+			},
+			RequestType::Write(key, value) => {
+				let res = the_storage.insert(key, value);
+
+				if let Some(sender) = request.response_sender {
+					// A callee wants to know about the errors
+					sender.send(Response::StorageStatusResponse(res)).unwrap();
+				}
+			},
+			RequestType::Replace(key, value) => {
+				let res = the_storage.replace(key, value);
+
+				if let Some(sender) = request.response_sender {
+					sender.send(Response::StorageReadResponse(res)).unwrap();
+				}
+			},
+			RequestType::Size => {
+				let size = the_storage.len();
+				request
+					.response_sender
+					.expect("no sender provided")
+					.send(Response::StorageSizeResponse(size))
+					.unwrap();
+			},
+			RequestType::Keys => {
+				let keys = the_storage.keys();
+				request
+					.response_sender
+					.expect("no sender provided")
+					.send(Response::StorageKeysResponse(keys))
+					.unwrap();
+			},
+			RequestType::KeysWithPrefix(_) => {
+				unimplemented!()
+			},
+		}
+	}
+}
+
+pub(crate) async fn api_handler_task_prefixed<K>(mut api: Receiver<Request<K>>, storage_config: RecordsStorageConfig)
+where
+	K: Ord + Sized + Hash + Debug + Clone + HasPrefix,
+{
 	// The storage lives here.
 	let mut the_storage = RecordsStorage::new(storage_config);
 

--- a/src/kvdb/tests.rs
+++ b/src/kvdb/tests.rs
@@ -39,7 +39,7 @@ fn make_temp_dir() -> PathBuf {
 	let mut rng = thread_rng();
 	let suffix: String = (0..20).map(|_| rng.sample(Alphanumeric) as char).collect();
 	let suffix = format!("intro-kvdb-test-{}", suffix);
-	let path = tmpdir.join(&suffix);
+	let path = tmpdir.join(suffix);
 	std::fs::create_dir(&path).unwrap();
 	path
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ pub(crate) struct IntrospectorCli {
 	pub command: Command,
 	/// Verbosity level: -v - info, -vv - debug, -vvv - trace
 	#[clap(short = 'v', long, action = ArgAction::Count)]
-	pub verbose: i8,
+	pub verbose: u8,
 }
 
 #[tokio::main]

--- a/src/pc/mod.rs
+++ b/src/pc/mod.rs
@@ -56,7 +56,7 @@ pub(crate) struct ParachainCommander {
 	opts: ParachainCommanderOptions,
 	node: String,
 	consumer_config: EventConsumerInit<SubxtEvent>,
-	api_service: ApiService,
+	api_service: ApiService<H256>,
 }
 
 impl ParachainCommander {
@@ -92,7 +92,7 @@ impl ParachainCommander {
 		opts: ParachainCommanderOptions,
 		url: String,
 		mut consumer_config: Receiver<SubxtEvent>,
-		api_service: ApiService,
+		api_service: ApiService<H256>,
 	) {
 		// The subxt API request executor.
 		let executor = api_service.subxt();


### PR DESCRIPTION
For some tools in the introspector, e.g. collector, we store multiple things using the same hash  (e.g. under relay chain block hash). To distinguish keys we need two changes:

* Use ordered structure (BTree) for keys, allowing to manipulate keys by some prefixes
* Change strict `H256` to a more generic type when dealing with the keys
