### PR TITLE
Another try to implement prefixed storage and fix the collector

### DIFF
--- a/src/block_time/mod.rs
+++ b/src/block_time/mod.rs
@@ -29,6 +29,7 @@ use std::{
 	io::{stdout, Write},
 	sync::{Arc, Mutex},
 };
+use subxt::sp_core::H256;
 use tokio::sync::mpsc::Receiver;
 
 #[derive(Clone, Debug, Parser)]
@@ -75,7 +76,7 @@ pub(crate) struct BlockTimeMonitor {
 	block_time_metric: Option<HistogramVec>,
 	endpoints: Vec<String>,
 	consumer_config: EventConsumerInit<SubxtEvent>,
-	api_service: ApiService,
+	api_service: ApiService<H256>,
 }
 
 impl BlockTimeMonitor {
@@ -198,7 +199,7 @@ impl BlockTimeMonitor {
 		values: Arc<Mutex<VecDeque<u64>>>,
 		// TODO: make this a struct.
 		mut consumer_config: Receiver<SubxtEvent>,
-		api_service: ApiService,
+		api_service: ApiService<H256>,
 	) {
 		// Make static string out of uri so we can use it as Prometheus label.
 		let url = leak_static_str(url);
@@ -269,7 +270,7 @@ async fn populate_view(
 	values: Arc<Mutex<VecDeque<u64>>>,
 	url: &str,
 	cli_opts: BlockTimeCliOptions,
-	api_service: ApiService,
+	api_service: ApiService<H256>,
 ) {
 	let mut prev_ts = 0u64;
 	let blocks_to_fetch = cli_opts.chart_width;

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -130,7 +130,7 @@ pub(crate) async fn run(
 	consumer_config: EventConsumerInit<SubxtEvent>,
 ) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>> {
 	let api_service =
-		ApiService::new_with_storage(RecordsStorageConfig { max_blocks: opts.max_blocks.unwrap_or(1000) });
+		ApiService::new_with_prefixed_storage(RecordsStorageConfig { max_blocks: opts.max_blocks.unwrap_or(1000) });
 	let (shutdown_tx, shutdown_rx) = broadcast::channel(1);
 	let (to_websocket, _) = broadcast::channel(32);
 	let endpoints = opts.nodes.clone().into_iter();

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -130,7 +130,7 @@ pub(crate) async fn run(
 	Ok(futures)
 }
 
-async fn process_new_head(url: &str, api_service: &ApiService, block_hash: H256) -> color_eyre::Result<()> {
+async fn process_new_head(url: &str, api_service: &ApiService<H256>, block_hash: H256) -> color_eyre::Result<()> {
 	let executor = api_service.subxt();
 	let ts = executor.get_block_timestamp(url.into(), Some(block_hash)).await;
 	let header = executor
@@ -149,7 +149,7 @@ async fn process_new_head(url: &str, api_service: &ApiService, block_hash: H256)
 }
 
 async fn process_candidate_change(
-	api_service: &ApiService,
+	api_service: &ApiService<H256>,
 	change_event: SubxtCandidateEvent,
 	to_websocket: &Sender<WebSocketUpdateEvent>,
 ) -> color_eyre::Result<()> {
@@ -274,7 +274,7 @@ async fn process_candidate_change(
 }
 
 async fn process_dispute_initiated(
-	api_service: &ApiService,
+	api_service: &ApiService<H256>,
 	dispute_event: SubxtDispute,
 	to_websocket: &Sender<WebSocketUpdateEvent>,
 ) -> color_eyre::Result<()> {
@@ -301,7 +301,7 @@ async fn process_dispute_initiated(
 }
 
 async fn process_dispute_concluded(
-	api_service: &ApiService,
+	api_service: &ApiService<H256>,
 	dispute_event: SubxtDispute,
 	dispute_outcome: SubxtDisputeResult,
 	to_websocket: &Sender<WebSocketUpdateEvent>,

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -146,6 +146,8 @@ pub(crate) async fn run(
 		.map(|(endpoint, mut update_channel)| {
 			let mut shutdown_rx = shutdown_tx.subscribe();
 			let to_websocket = to_websocket.clone();
+			// Subscribe to events to have at least one consumer
+			let mut from_websocket = to_websocket.subscribe();
 			let api_service = api_service.clone();
 
 			tokio::spawn(async move {
@@ -180,6 +182,10 @@ pub(crate) async fn run(
 						_ = shutdown_rx.recv() => {
 							info!("shutting down");
 							break;
+						},
+						_ = from_websocket.recv() => {
+							debug!("received own WS update");
+							continue;
 						}
 					}
 				}

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -238,7 +238,7 @@ async fn process_candidate_change(
 						"no stored relay parent {} for candidate {}",
 						change_event.candidate_descriptor.relay_parent,
 						change_event.candidate_hash
-					));
+					))
 				}
 			}
 		},

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -101,9 +101,8 @@ impl HasPrefix for CollectorKey {
 			CollectorPrefixType::Head => other.prefix == self.prefix,
 			CollectorPrefixType::Candidate(maybe_para) => match other.prefix {
 				CollectorPrefixType::Head => false,
-				CollectorPrefixType::Candidate(maybe_other_para) => {
-					maybe_other_para.is_none() || maybe_para.is_none() || maybe_para == maybe_other_para
-				},
+				CollectorPrefixType::Candidate(maybe_other_para) =>
+					maybe_other_para.is_none() || maybe_para.is_none() || maybe_para == maybe_other_para,
 			},
 		}
 	}
@@ -295,7 +294,7 @@ async fn process_candidate_change(
 						"no stored relay parent {} for candidate {}",
 						change_event.candidate_descriptor.relay_parent,
 						change_event.candidate_hash
-					));
+					))
 				}
 			}
 		},

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -32,8 +32,8 @@ mod candidate_record;
 mod ws;
 
 use crate::core::{
-	ApiService, EventConsumerInit, RecordTime, RecordsStorageConfig, StorageEntry, StorageInfo, SubxtCandidateEvent,
-	SubxtCandidateEventType, SubxtDispute, SubxtDisputeResult, SubxtEvent,
+	ApiService, EventConsumerInit, HasPrefix, RecordTime, RecordsStorageConfig, StorageEntry, StorageInfo,
+	SubxtCandidateEvent, SubxtCandidateEventType, SubxtDispute, SubxtDisputeResult, SubxtEvent,
 };
 use candidate_record::*;
 use color_eyre::eyre::eyre;
@@ -65,6 +65,12 @@ impl From<CollectorOptions> for WebSocketListenerConfig {
 pub(crate) struct CollectorKey {
 	pub prefix: String,
 	pub hash: Option<H256>,
+}
+
+impl HasPrefix for CollectorKey {
+	fn has_prefix(&self, prefix: &Self) -> bool {
+		self.prefix == prefix.prefix
+	}
 }
 
 pub(crate) const CANDIDATE_PREFIX: &str = "candidate";

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -15,7 +15,6 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 
 use clap::Parser;
-use codec::Encode;
 use log::{debug, info, warn};
 use std::{
 	default::Default,
@@ -102,8 +101,9 @@ impl HasPrefix for CollectorKey {
 			CollectorPrefixType::Head => other.prefix == self.prefix,
 			CollectorPrefixType::Candidate(maybe_para) => match other.prefix {
 				CollectorPrefixType::Head => false,
-				CollectorPrefixType::Candidate(maybe_other_para) =>
-					maybe_other_para.is_none() || maybe_para.is_none() || maybe_para == maybe_other_para,
+				CollectorPrefixType::Candidate(maybe_other_para) => {
+					maybe_other_para.is_none() || maybe_para.is_none() || maybe_para == maybe_other_para
+				},
 			},
 		}
 	}
@@ -215,7 +215,7 @@ async fn process_new_head(
 		.storage()
 		.storage_write(
 			CollectorKey::new_relay_chain_block(block_hash),
-			StorageEntry::new_onchain(RecordTime::with_ts(header.number, Duration::from_secs(ts)), header.encode()),
+			StorageEntry::new_onchain(RecordTime::with_ts(header.number, Duration::from_secs(ts)), header),
 		)
 		.await
 		.unwrap();
@@ -277,7 +277,7 @@ async fn process_candidate_change(
 							),
 							StorageEntry::new_onchain(
 								RecordTime::with_ts(block_number, Duration::from_secs(now.as_secs())),
-								new_record.encode(),
+								new_record,
 							),
 						)
 						.await
@@ -295,7 +295,7 @@ async fn process_candidate_change(
 						"no stored relay parent {} for candidate {}",
 						change_event.candidate_descriptor.relay_parent,
 						change_event.candidate_hash
-					))
+					));
 				}
 			}
 		},
@@ -325,7 +325,7 @@ async fn process_candidate_change(
 					.storage()
 					.storage_replace(
 						CollectorKey::new_parachain_candidate(change_event.candidate_hash, change_event.parachain_id),
-						StorageEntry::new_onchain(record_time, known_candidate.encode()),
+						StorageEntry::new_onchain(record_time, known_candidate),
 					)
 					.await;
 			} else {
@@ -358,7 +358,7 @@ async fn process_candidate_change(
 					.storage()
 					.storage_replace(
 						CollectorKey::new_parachain_candidate(change_event.candidate_hash, change_event.parachain_id),
-						StorageEntry::new_onchain(record_time, known_candidate.encode()),
+						StorageEntry::new_onchain(record_time, known_candidate),
 					)
 					.await;
 			} else {
@@ -393,7 +393,7 @@ async fn process_dispute_initiated(
 		.storage()
 		.storage_replace(
 			CollectorKey::new_generic_hash(dispute_event.candidate_hash),
-			StorageEntry::new_onchain(record_time, candidate.encode()),
+			StorageEntry::new_onchain(record_time, candidate),
 		)
 		.await;
 	Ok(())
@@ -428,7 +428,7 @@ async fn process_dispute_concluded(
 		.storage()
 		.storage_replace(
 			CollectorKey::new_generic_hash(dispute_event.candidate_hash),
-			StorageEntry::new_onchain(record_time, candidate.encode()),
+			StorageEntry::new_onchain(record_time, candidate),
 		)
 		.await;
 	Ok(())

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -102,8 +102,9 @@ impl HasPrefix for CollectorKey {
 			CollectorPrefixType::Head => other.prefix == self.prefix,
 			CollectorPrefixType::Candidate(maybe_para) => match other.prefix {
 				CollectorPrefixType::Head => false,
-				CollectorPrefixType::Candidate(maybe_other_para) =>
-					maybe_other_para.is_none() || maybe_para == maybe_other_para,
+				CollectorPrefixType::Candidate(maybe_other_para) => {
+					maybe_other_para.is_none() || maybe_para.is_none() || maybe_para == maybe_other_para
+				},
 			},
 		}
 	}
@@ -114,7 +115,7 @@ impl HasPrefix for CollectorKey {
 // a specific entry with no hash
 impl PartialEq for CollectorKey {
 	fn eq(&self, other: &Self) -> bool {
-		self.hash == other.hash && self.has_prefix(other)
+		self.hash == other.hash && (self.has_prefix(other) || other.has_prefix(self))
 	}
 }
 
@@ -289,7 +290,7 @@ async fn process_candidate_change(
 						"no stored relay parent {} for candidate {}",
 						change_event.candidate_descriptor.relay_parent,
 						change_event.candidate_hash
-					))
+					));
 				}
 			}
 		},

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -102,9 +102,8 @@ impl HasPrefix for CollectorKey {
 			CollectorPrefixType::Head => other.prefix == self.prefix,
 			CollectorPrefixType::Candidate(maybe_para) => match other.prefix {
 				CollectorPrefixType::Head => false,
-				CollectorPrefixType::Candidate(maybe_other_para) => {
-					maybe_other_para.is_none() || maybe_para.is_none() || maybe_para == maybe_other_para
-				},
+				CollectorPrefixType::Candidate(maybe_other_para) =>
+					maybe_other_para.is_none() || maybe_para.is_none() || maybe_para == maybe_other_para,
 			},
 		}
 	}
@@ -290,7 +289,7 @@ async fn process_candidate_change(
 						"no stored relay parent {} for candidate {}",
 						change_event.candidate_descriptor.relay_parent,
 						change_event.candidate_hash
-					));
+					))
 				}
 			}
 		},

--- a/src/collector/ws.rs
+++ b/src/collector/ws.rs
@@ -223,7 +223,7 @@ async fn candidates_handler(
 ) -> Result<impl Reply, Rejection> {
 	let keys = api
 		.storage()
-		.storage_keys(Some(CollectorKey { prefix: CANDIDATE_PREFIX.into(), hash: None }))
+		.storage_keys_prefix(CollectorKey::new_with_prefix(CANDIDATE_PREFIX))
 		.await;
 	// TODO: add filters support somehow...
 
@@ -242,7 +242,7 @@ async fn candidate_get_handler(
 ) -> Result<impl Reply, Rejection> {
 	let candidate_record = api
 		.storage()
-		.storage_read(CollectorKey { prefix: CANDIDATE_PREFIX.into(), hash: Some(candidate_hash.hash) })
+		.storage_read(CollectorKey::new_with_hash(CANDIDATE_PREFIX, candidate_hash.hash))
 		.await;
 
 	match candidate_record {

--- a/src/collector/ws.rs
+++ b/src/collector/ws.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 use crate::{
-	collector::{candidate_record::CandidateRecord, CollectorKey, CANDIDATE_PREFIX},
+	collector::{candidate_record::CandidateRecord, CollectorKey, CollectorKeyPrefix},
 	core::{api::ApiService, SubxtDisputeResult},
 };
 use futures::{SinkExt, StreamExt};
@@ -223,7 +223,7 @@ async fn candidates_handler(
 ) -> Result<impl Reply, Rejection> {
 	let keys = api
 		.storage()
-		.storage_keys_prefix(CollectorKey::new_with_prefix(CANDIDATE_PREFIX))
+		.storage_keys_prefix(CollectorKey::new_with_prefix(CollectorKeyPrefix::Candidate))
 		.await;
 	// TODO: add filters support somehow...
 
@@ -242,7 +242,7 @@ async fn candidate_get_handler(
 ) -> Result<impl Reply, Rejection> {
 	let candidate_record = api
 		.storage()
-		.storage_read(CollectorKey::new_with_hash(CANDIDATE_PREFIX, candidate_hash.hash))
+		.storage_read(CollectorKey::new_with_hash(CollectorKeyPrefix::Candidate, candidate_hash.hash))
 		.await;
 
 	match candidate_record {

--- a/src/collector/ws.rs
+++ b/src/collector/ws.rs
@@ -225,8 +225,14 @@ async fn candidates_handler(
 	let keys = if let Some(para_id) = filter.and_then(|filt| filt.parachain_id) {
 		api.storage().storage_keys_prefix(CollectorPrefixType::Candidate(para_id)).await
 	} else {
-		// TODO: Exclude heads
-		api.storage().storage_keys().await
+		let mut output: Vec<H256> = vec![];
+		for prefix in api.storage().storage_prefixes().await {
+			if let CollectorPrefixType::Candidate(_) = &prefix {
+				output.extend(api.storage().storage_keys_prefix(prefix).await);
+			}
+		}
+
+		output
 	};
 
 	Ok(warp::reply::json(&keys.into_iter().collect::<Vec<_>>().as_slice()))

--- a/src/collector/ws.rs
+++ b/src/collector/ws.rs
@@ -281,14 +281,14 @@ where
 						},
 						Err(err) => {
 							warn!("{:?} cannot send data: {:?}", remote.as_ref(), err);
-							return;
+							return
 						},
 					}
 				},
 				Err(err) => {
 					warn!("{:?} update channel error = {:?}", remote.as_ref(), err);
 
-					return;
+					return
 				},
 			}
 		}

--- a/src/core/api/mod.rs
+++ b/src/core/api/mod.rs
@@ -16,7 +16,7 @@
 //
 #![allow(dead_code)]
 
-use crate::core::{RecordsStorageConfig, MAX_MSG_QUEUE_SIZE};
+use crate::core::{HasPrefix, RecordsStorageConfig, MAX_MSG_QUEUE_SIZE};
 use std::{fmt::Debug, hash::Hash};
 use tokio::sync::mpsc::{channel, Sender};
 
@@ -27,14 +27,14 @@ pub use subxt_wrapper::*;
 
 // Provides access to subxt and storage APIs, more to come.
 #[derive(Clone)]
-pub struct ApiService<K: Ord + Hash> {
+pub struct ApiService<K: Ord + Hash + HasPrefix> {
 	subxt_tx: Sender<subxt_wrapper::Request>,
 	storage_tx: Sender<storage::Request<K>>,
 }
 
 impl<K> ApiService<K>
 where
-	K: Ord + Sized + Hash + Debug + Clone + Send + 'static,
+	K: Ord + Sized + Hash + Debug + Clone + Send + 'static + HasPrefix,
 {
 	pub fn new_with_storage(storage_config: RecordsStorageConfig) -> ApiService<K> {
 		let (subxt_tx, subxt_rx) = channel(MAX_MSG_QUEUE_SIZE);

--- a/src/core/api/mod.rs
+++ b/src/core/api/mod.rs
@@ -27,14 +27,14 @@ pub use subxt_wrapper::*;
 
 // Provides access to subxt and storage APIs, more to come.
 #[derive(Clone)]
-pub struct ApiService<K: Ord + Hash + HasPrefix> {
+pub struct ApiService<K: Ord + Hash> {
 	subxt_tx: Sender<subxt_wrapper::Request>,
 	storage_tx: Sender<storage::Request<K>>,
 }
 
 impl<K> ApiService<K>
 where
-	K: Ord + Sized + Hash + Debug + Clone + Send + 'static + HasPrefix,
+	K: Ord + Sized + Hash + Debug + Clone + Send + 'static,
 {
 	pub fn new_with_storage(storage_config: RecordsStorageConfig) -> ApiService<K> {
 		let (subxt_tx, subxt_rx) = channel(MAX_MSG_QUEUE_SIZE);
@@ -55,6 +55,20 @@ where
 	}
 }
 
+impl<K> ApiService<K>
+where
+	K: Ord + Sized + Hash + Debug + Clone + Send + HasPrefix + 'static,
+{
+	pub fn new_with_prefixed_storage(storage_config: RecordsStorageConfig) -> ApiService<K> {
+		let (subxt_tx, subxt_rx) = channel(MAX_MSG_QUEUE_SIZE);
+		let (storage_tx, storage_rx) = channel(MAX_MSG_QUEUE_SIZE);
+
+		tokio::spawn(subxt_wrapper::api_handler_task(subxt_rx));
+		tokio::spawn(storage::api_handler_task_prefixed(storage_rx, storage_config));
+
+		Self { subxt_tx, storage_tx }
+	}
+}
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/src/core/api/storage.rs
+++ b/src/core/api/storage.rs
@@ -129,7 +129,7 @@ impl<K: Ord + Hash + Sized + Debug> RequestExecutor<K> {
 	}
 }
 
-// A task that handles storage API calls.
+/// Creates a task that handles storage API calls (generic version with no prefixes support).
 pub(crate) async fn api_handler_task<K>(mut api: Receiver<Request<K>>, storage_config: RecordsStorageConfig)
 where
 	K: Ord + Sized + Hash + Debug + Clone,
@@ -184,6 +184,7 @@ where
 	}
 }
 
+/// Creates the API handler with prefixes support. `K` must has `HasPrefix` trait
 pub(crate) async fn api_handler_task_prefixed<K>(mut api: Receiver<Request<K>>, storage_config: RecordsStorageConfig)
 where
 	K: Ord + Sized + Hash + Debug + Clone + HasPrefix,

--- a/src/core/api/storage.rs
+++ b/src/core/api/storage.rs
@@ -28,7 +28,7 @@ use tokio::sync::{
 
 // Storage requests
 #[derive(Clone, Debug)]
-pub enum RequestType<K: Ord + Hash + Sized + HasPrefix> {
+pub enum RequestType<K: Ord + Hash + Sized> {
 	Write(K, StorageEntry),
 	Read(K),
 	Replace(K, StorageEntry),
@@ -38,23 +38,23 @@ pub enum RequestType<K: Ord + Hash + Sized + HasPrefix> {
 }
 
 #[derive(Debug)]
-pub struct Request<K: Ord + Hash + Sized + HasPrefix> {
+pub struct Request<K: Ord + Hash + Sized> {
 	pub request_type: RequestType<K>,
 	pub response_sender: Option<oneshot::Sender<Response<K>>>,
 }
 
 #[derive(Debug)]
-pub enum Response<K: Ord + Hash + Sized + HasPrefix> {
+pub enum Response<K: Ord + Hash + Sized> {
 	StorageReadResponse(Option<StorageEntry>),
 	StorageSizeResponse(usize),
 	StorageKeysResponse(Vec<K>),
 	StorageStatusResponse(color_eyre::Result<()>),
 }
-pub struct RequestExecutor<K: Ord + Hash + Sized + HasPrefix> {
+pub struct RequestExecutor<K: Ord + Hash + Sized> {
 	to_api: Sender<Request<K>>,
 }
 
-impl<K: Ord + Hash + Sized + Debug + HasPrefix> RequestExecutor<K> {
+impl<K: Ord + Hash + Sized + Debug> RequestExecutor<K> {
 	pub fn new(to_api: Sender<Request<K>>) -> Self {
 		RequestExecutor { to_api }
 	}
@@ -130,10 +130,64 @@ impl<K: Ord + Hash + Sized + Debug + HasPrefix> RequestExecutor<K> {
 }
 
 // A task that handles storage API calls.
-pub(crate) async fn api_handler_task<K: Ord + Sized + Hash + Debug + Clone + HasPrefix>(
-	mut api: Receiver<Request<K>>,
-	storage_config: RecordsStorageConfig,
-) {
+pub(crate) async fn api_handler_task<K>(mut api: Receiver<Request<K>>, storage_config: RecordsStorageConfig)
+where
+	K: Ord + Sized + Hash + Debug + Clone,
+{
+	// The storage lives here.
+	let mut the_storage = RecordsStorage::new(storage_config);
+
+	while let Some(request) = api.recv().await {
+		match request.request_type {
+			RequestType::Read(key) => {
+				request
+					.response_sender
+					.expect("no sender provided")
+					.send(Response::StorageReadResponse(the_storage.get(&key)))
+					.unwrap();
+			},
+			RequestType::Write(key, value) => {
+				let res = the_storage.insert(key, value);
+
+				if let Some(sender) = request.response_sender {
+					// A callee wants to know about the errors
+					sender.send(Response::StorageStatusResponse(res)).unwrap();
+				}
+			},
+			RequestType::Replace(key, value) => {
+				let res = the_storage.replace(key, value);
+
+				if let Some(sender) = request.response_sender {
+					sender.send(Response::StorageReadResponse(res)).unwrap();
+				}
+			},
+			RequestType::Size => {
+				let size = the_storage.len();
+				request
+					.response_sender
+					.expect("no sender provided")
+					.send(Response::StorageSizeResponse(size))
+					.unwrap();
+			},
+			RequestType::Keys => {
+				let keys = the_storage.keys();
+				request
+					.response_sender
+					.expect("no sender provided")
+					.send(Response::StorageKeysResponse(keys))
+					.unwrap();
+			},
+			RequestType::KeysWithPrefix(_) => {
+				unimplemented!()
+			},
+		}
+	}
+}
+
+pub(crate) async fn api_handler_task_prefixed<K>(mut api: Receiver<Request<K>>, storage_config: RecordsStorageConfig)
+where
+	K: Ord + Sized + Hash + Debug + Clone + HasPrefix,
+{
 	// The storage lives here.
 	let mut the_storage = RecordsStorage::new(storage_config);
 

--- a/src/core/storage.rs
+++ b/src/core/storage.rs
@@ -27,7 +27,7 @@ use crate::eyre;
 use codec::{Decode, Encode};
 use std::{
 	borrow::Borrow,
-	collections::{HashMap, HashSet},
+	collections::{BTreeMap, HashMap, HashSet},
 	fmt::Debug,
 	hash::Hash,
 	time::Duration,
@@ -166,7 +166,7 @@ pub struct HashedPlainRecordsStorage<K: Hash + Clone> {
 	/// The last block number we've seen. Used to index the storage of all entries.
 	last_block: Option<BlockNumber>,
 	/// Elements with expire dates.
-	ephemeral_records: HashMap<BlockNumber, HashSet<K>>,
+	ephemeral_records: BTreeMap<BlockNumber, HashSet<K>>,
 	/// Direct mapping to values.
 	direct_records: HashMap<K, StorageEntry>,
 }
@@ -176,7 +176,7 @@ where
 	K: Hash + Clone + Eq + Debug,
 {
 	fn new(config: RecordsStorageConfig) -> Self {
-		let ephemeral_records = HashMap::new();
+		let ephemeral_records = BTreeMap::new();
 		let direct_records = HashMap::new();
 		Self { config, last_block: None, ephemeral_records, direct_records }
 	}
@@ -289,7 +289,7 @@ pub struct HashedPrefixedRecordsStorage<K: Hash + Clone, P: Hash + Clone> {
 	/// The last block number we've seen. Used to index the storage of all entries.
 	last_block: Option<BlockNumber>,
 	/// Elements with expire dates.
-	ephemeral_records: HashMap<BlockNumber, HashSet<K>>,
+	ephemeral_records: BTreeMap<BlockNumber, HashSet<K>>,
 	/// Direct mapping to values.
 	prefixed_records: HashMap<P, HashMap<K, StorageEntry>>,
 }
@@ -300,7 +300,7 @@ where
 	P: Hash + Clone + Eq + Debug,
 {
 	fn new(config: RecordsStorageConfig) -> Self {
-		let ephemeral_records = HashMap::new();
+		let ephemeral_records = BTreeMap::new();
 		let prefixed_records = HashMap::new();
 		Self { config, last_block: None, ephemeral_records, prefixed_records }
 	}
@@ -457,8 +457,10 @@ mod tests {
 	fn test_it_works() {
 		let mut st = HashedPlainRecordsStorage::new(RecordsStorageConfig { max_blocks: 1 });
 
-		st.insert("key1".to_owned(), StorageEntry::new_onchain(1.into(), 1)).unwrap();
-		st.insert("key100".to_owned(), StorageEntry::new_offchain(1.into(), 2)).unwrap();
+		st.insert("key1".to_owned(), StorageEntry::new_onchain(1.into(), 1_u32))
+			.unwrap();
+		st.insert("key100".to_owned(), StorageEntry::new_offchain(1.into(), 2_u32))
+			.unwrap();
 
 		let a = st.get("key1").unwrap();
 		assert_eq!(a.record_source, RecordSource::Onchain);
@@ -470,7 +472,7 @@ mod tests {
 		assert_eq!(st.get("key2"), None);
 
 		// This insert prunes prev entries at block #1
-		st.insert("key2".to_owned(), StorageEntry::new_onchain(100.into(), 100))
+		st.insert("key2".to_owned(), StorageEntry::new_onchain(100.into(), 100_u32))
 			.unwrap();
 		assert_eq!(st.get("key2").unwrap().into_inner::<u32>().unwrap(), 100);
 

--- a/src/core/storage.rs
+++ b/src/core/storage.rs
@@ -272,6 +272,8 @@ pub trait PrefixedRecordsStorage<K, P> {
 	fn prefixed_keys<PQ: ?Sized + Hash + Eq>(&self, prefix: &PQ) -> Vec<K>
 	where
 		P: Borrow<PQ>;
+	/// Get all prefixes from a storage
+	fn prefixes(&self) -> Vec<P>;
 }
 
 /// Prefixed storage is distinct as it organise data stored using prefixes,
@@ -428,6 +430,10 @@ where
 		} else {
 			vec![]
 		}
+	}
+
+	fn prefixes(&self) -> Vec<P> {
+		self.prefixed_records.keys().cloned().collect()
 	}
 }
 

--- a/src/core/storage.rs
+++ b/src/core/storage.rs
@@ -184,7 +184,7 @@ where
 	// TODO: must fail for values with blocks below the pruning threshold.
 	fn insert(&mut self, key: K, entry: StorageEntry) -> color_eyre::Result<()> {
 		if self.direct_records.contains_key(&key) {
-			return Err(eyre!("duplicate key: {:?}", key))
+			return Err(eyre!("duplicate key: {:?}", key));
 		}
 		let block_number = entry.time().block_number();
 		self.last_block = Some(block_number);
@@ -304,17 +304,17 @@ where
 	}
 
 	// We cannot insert non prefixed key into a prefixed storage
-	fn insert(&mut self, key: K, entry: StorageEntry) -> color_eyre::Result<()> {
-		return Err(eyre!("trying to insert key with no prefix to the prefixed storage: {:?}", key))
+	fn insert(&mut self, key: K, _: StorageEntry) -> color_eyre::Result<()> {
+		return Err(eyre!("trying to insert key with no prefix to the prefixed storage: {:?}", key));
 	}
 
 	fn replace<Q: ?Sized + Hash + Eq>(&mut self, key: &Q, entry: StorageEntry) -> Option<StorageEntry>
 	where
 		K: Borrow<Q>,
 	{
-		for (_, mut direct_map) in &self.prefixed_records {
+		for (_, direct_map) in &mut self.prefixed_records {
 			if let Some(record) = direct_map.get_mut(key) {
-				return Some(std::mem::replace(record, entry))
+				return Some(std::mem::replace(record, entry));
 			}
 		}
 
@@ -329,7 +329,7 @@ where
 			let oldest_block = {
 				let (oldest_block, entries) = self.ephemeral_records.iter().next().unwrap();
 				for key in entries.iter() {
-					for (_, mut direct_map) in &self.prefixed_records {
+					for (_, direct_map) in &mut self.prefixed_records {
 						direct_map.remove(key);
 					}
 				}
@@ -372,9 +372,9 @@ where
 	P: Hash + Clone + Eq + Debug,
 {
 	fn insert_prefix(&mut self, prefix: P, key: K, entry: StorageEntry) -> color_eyre::Result<()> {
-		let mut direct_storage = self.prefixed_records.entry(prefix).or_default();
+		let direct_storage = self.prefixed_records.entry(prefix).or_default();
 		if direct_storage.contains_key(&key) {
-			return Err(eyre!("duplicate key: {:?}", key))
+			return Err(eyre!("duplicate key: {:?}", key));
 		}
 		let block_number = entry.time().block_number();
 		self.last_block = Some(block_number);
@@ -399,7 +399,7 @@ where
 		K: Borrow<Q>,
 		P: Borrow<PQ>,
 	{
-		let mut direct_storage = self.prefixed_records.get_mut(prefix)?;
+		let direct_storage = self.prefixed_records.get_mut(prefix)?;
 		if !direct_storage.contains_key(key) {
 			None
 		} else {
@@ -414,7 +414,7 @@ where
 		P: Borrow<PQ>,
 	{
 		if let Some(direct_storage) = self.prefixed_records.get(prefix) {
-			return direct_storage.get(key).cloned()
+			return direct_storage.get(key).cloned();
 		}
 
 		None

--- a/src/core/storage.rs
+++ b/src/core/storage.rs
@@ -251,9 +251,11 @@ where
 /// Prefixes are used to group elements by some characteristic. For example, to get
 /// elements that belong to some particular parachain.
 pub trait PrefixedRecordsStorage<K, P> {
-	/// Insert a prefixed entry to the storage
+	/// Insert a prefixed entry to the storage, returns a usage Error if trying to insert a duplicate
+	/// key + prefix
 	fn insert_prefix(&mut self, prefix: P, key: K, entry: StorageEntry) -> color_eyre::Result<()>;
-	/// Replaces a prefixed entry in the storage, both prefix and a key must exist
+	/// Replaces a prefixed entry in the storage, both prefix and a key must exist,
+	/// returns the old entry on success and None on error
 	fn replace_prefix<Q: ?Sized + Hash + Eq, PQ: ?Sized + Hash + Eq>(
 		&mut self,
 		prefix: &PQ,

--- a/src/core/storage.rs
+++ b/src/core/storage.rs
@@ -184,7 +184,7 @@ where
 	// TODO: must fail for values with blocks below the pruning threshold.
 	fn insert(&mut self, key: K, entry: StorageEntry) -> color_eyre::Result<()> {
 		if self.direct_records.contains_key(&key) {
-			return Err(eyre!("duplicate key: {:?}", key));
+			return Err(eyre!("duplicate key: {:?}", key))
 		}
 		let block_number = entry.time().block_number();
 		self.last_block = Some(block_number);
@@ -305,16 +305,16 @@ where
 
 	// We cannot insert non prefixed key into a prefixed storage
 	fn insert(&mut self, key: K, _: StorageEntry) -> color_eyre::Result<()> {
-		return Err(eyre!("trying to insert key with no prefix to the prefixed storage: {:?}", key));
+		return Err(eyre!("trying to insert key with no prefix to the prefixed storage: {:?}", key))
 	}
 
 	fn replace<Q: ?Sized + Hash + Eq>(&mut self, key: &Q, entry: StorageEntry) -> Option<StorageEntry>
 	where
 		K: Borrow<Q>,
 	{
-		for (_, direct_map) in &mut self.prefixed_records {
+		for direct_map in self.prefixed_records.values_mut() {
 			if let Some(record) = direct_map.get_mut(key) {
-				return Some(std::mem::replace(record, entry));
+				return Some(std::mem::replace(record, entry))
 			}
 		}
 
@@ -329,7 +329,7 @@ where
 			let oldest_block = {
 				let (oldest_block, entries) = self.ephemeral_records.iter().next().unwrap();
 				for key in entries.iter() {
-					for (_, direct_map) in &mut self.prefixed_records {
+					for direct_map in self.prefixed_records.values_mut() {
 						direct_map.remove(key);
 					}
 				}
@@ -353,14 +353,13 @@ where
 	}
 
 	fn len(&self) -> usize {
-		self.prefixed_records.iter().map(|(_, direct_map)| direct_map.len()).sum()
+		self.prefixed_records.values().map(|direct_map| direct_map.len()).sum()
 	}
 
 	fn keys(&self) -> Vec<K> {
 		self.prefixed_records
-			.iter()
-			.map(|(_, direct_map)| direct_map.keys())
-			.flatten()
+			.values()
+			.flat_map(|direct_map| direct_map.keys())
 			.cloned()
 			.collect()
 	}
@@ -374,7 +373,7 @@ where
 	fn insert_prefix(&mut self, prefix: P, key: K, entry: StorageEntry) -> color_eyre::Result<()> {
 		let direct_storage = self.prefixed_records.entry(prefix).or_default();
 		if direct_storage.contains_key(&key) {
-			return Err(eyre!("duplicate key: {:?}", key));
+			return Err(eyre!("duplicate key: {:?}", key))
 		}
 		let block_number = entry.time().block_number();
 		self.last_block = Some(block_number);
@@ -414,7 +413,7 @@ where
 		P: Borrow<PQ>,
 	{
 		if let Some(direct_storage) = self.prefixed_records.get(prefix) {
-			return direct_storage.get(key).cloned();
+			return direct_storage.get(key).cloned()
 		}
 
 		None
@@ -424,7 +423,7 @@ where
 	where
 		P: Borrow<PQ>,
 	{
-		if let Some(direct_storage) = self.prefixed_records.get(&prefix) {
+		if let Some(direct_storage) = self.prefixed_records.get(prefix) {
 			direct_storage.keys().cloned().collect()
 		} else {
 			vec![]

--- a/src/kvdb/tests.rs
+++ b/src/kvdb/tests.rs
@@ -39,7 +39,7 @@ fn make_temp_dir() -> PathBuf {
 	let mut rng = thread_rng();
 	let suffix: String = (0..20).map(|_| rng.sample(Alphanumeric) as char).collect();
 	let suffix = format!("intro-kvdb-test-{}", suffix);
-	let path = tmpdir.join(&suffix);
+	let path = tmpdir.join(suffix);
 	std::fs::create_dir(&path).unwrap();
 	path
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ pub(crate) struct IntrospectorCli {
 	pub command: Command,
 	/// Verbosity level: -v - info, -vv - debug, -vvv - trace
 	#[clap(short = 'v', long, action = ArgAction::Count)]
-	pub verbose: i8,
+	pub verbose: u8,
 }
 
 #[tokio::main]

--- a/src/pc/mod.rs
+++ b/src/pc/mod.rs
@@ -56,7 +56,7 @@ pub(crate) struct ParachainCommander {
 	opts: ParachainCommanderOptions,
 	node: String,
 	consumer_config: EventConsumerInit<SubxtEvent>,
-	api_service: ApiService,
+	api_service: ApiService<H256>,
 }
 
 impl ParachainCommander {
@@ -92,7 +92,7 @@ impl ParachainCommander {
 		opts: ParachainCommanderOptions,
 		url: String,
 		mut consumer_config: Receiver<SubxtEvent>,
-		api_service: ApiService,
+		api_service: ApiService<H256>,
 	) {
 		// The subxt API request executor.
 		let executor = api_service.subxt();


### PR DESCRIPTION
This PR is intended to fix the following tasks:

- [x] Allow to have generic storage
- [x] Allow to have a specific storage version to store hashes with prefixes
- [x] Do not break other tools
- [x] Implement prefixed and non-prefixed methods for storage types (prefixed storage is an extended generic storage)
- [x] Fix collector tool to work with prefixes properly
- [x] Adjust tests
- [x] Fix websocket counterpart to support prefixed searches
- [x] Allow to get prefixes from a storage
