### PR TITLE
Display HRMP/XCM channels for parachains

### DIFF
--- a/src/core/api/subxt_wrapper.rs
+++ b/src/core/api/subxt_wrapper.rs
@@ -69,6 +69,8 @@ pub enum RequestType {
 	GetSessionAccountKeys(u32),
 	/// Get information about inbound HRMP channels, accepts block hash and destination ParaId
 	GetInboundHRMPChannels(<DefaultConfig as subxt::Config>::Hash, u32),
+	/// Get data from a specific inbound HRMP channel
+	GetInboundHRMPData(<DefaultConfig as subxt::Config>::Hash, u32, u32),
 }
 
 /// The `InherentData` constructed with the subxt API.
@@ -102,8 +104,10 @@ pub enum Response {
 	SessionInfo(Option<polkadot_rt_primitives::v2::SessionInfo>),
 	/// Session keys
 	SessionAccountKeys(Option<Vec<AccountId32>>),
-	/// HRMP channels
-	HRMPChannels(Vec<u32>),
+	/// HRMP channels for some parachain (e.g. who are sending messages to us)
+	HRMPInboundChannels(Vec<u32>),
+	/// HRMP content for a specific channel
+	HRMPInboundContent(Vec<Vec<u8>>),
 }
 
 #[derive(Debug)]
@@ -284,8 +288,29 @@ impl RequestExecutor {
 		self.to_api.send(request).await.expect("Channel closed");
 
 		match receiver.await {
-			Ok(Response::HRMPChannels(channels)) => channels,
-			_ => panic!("Expected HrmpChannels, got something else."),
+			Ok(Response::HRMPInboundChannels(channels)) => channels,
+			_ => panic!("Expected HRMPInboundChannels, got something else."),
+		}
+	}
+
+	pub async fn get_inbound_hrmp_content(
+		&self,
+		url: String,
+		block_hash: <DefaultConfig as subxt::Config>::Hash,
+		para_id: u32,
+		sender_id: u32,
+	) -> Vec<Vec<u8>> {
+		let (sender, receiver) = oneshot::channel::<Response>();
+		let request = Request {
+			url,
+			request_type: RequestType::GetInboundHRMPData(block_hash, para_id, sender_id),
+			response_sender: sender,
+		};
+		self.to_api.send(request).await.expect("Channel closed");
+
+		match receiver.await {
+			Ok(Response::HRMPInboundContent(data)) => data,
+			_ => panic!("Expected HRMPInboundContent, got something else."),
 		}
 	}
 }
@@ -296,15 +321,14 @@ async fn new_client_fn(
 ) -> Option<polkadot::RuntimeApi<DefaultConfig, PolkadotExtrinsicParams<DefaultConfig>>> {
 	for _ in 0..crate::core::RETRY_COUNT {
 		match ClientBuilder::new().set_url(url.clone()).build().await {
-			Ok(api) => {
+			Ok(api) =>
 				return Some(
 					api.to_runtime_api::<polkadot::RuntimeApi<DefaultConfig, PolkadotExtrinsicParams<DefaultConfig>>>(),
-				)
-			},
+				),
 			Err(err) => {
 				error!("[{}] Client error: {:?}", url, err);
 				tokio::time::sleep(std::time::Duration::from_millis(crate::core::RETRY_DELAY_MS)).await;
-				continue;
+				continue
 			},
 		};
 	}
@@ -358,18 +382,18 @@ pub(crate) async fn api_handler_task(mut api: Receiver<Request>) {
 					RequestType::GetBackingGroups(hash) => subxt_get_validator_groups(api, hash).await,
 					RequestType::GetSessionIndex(hash) => subxt_get_session_index(api, hash).await,
 					RequestType::GetSessionInfo(session_index) => subxt_get_session_info(api, session_index).await,
-					RequestType::GetSessionAccountKeys(session_index) => {
-						subxt_get_session_account_keys(api, session_index).await
-					},
-					RequestType::GetInboundHRMPChannels(hash, para_id) => {
-						subxt_get_hrmp_channels(api, hash, para_id).await
-					},
+					RequestType::GetSessionAccountKeys(session_index) =>
+						subxt_get_session_account_keys(api, session_index).await,
+					RequestType::GetInboundHRMPChannels(hash, para_id) =>
+						subxt_get_hrmp_channels(api, hash, para_id).await,
+					RequestType::GetInboundHRMPData(hash, para_id, sender) =>
+						subxt_get_hrmp_content(api, hash, para_id, sender).await,
 				}
 			} else {
 				// Remove the faulty websocket from connection pool.
 				let _ = connection_pool.remove(&request.url);
 				tokio::time::sleep(std::time::Duration::from_millis(crate::core::RETRY_DELAY_MS)).await;
-				continue;
+				continue
 			};
 
 			let response = match result {
@@ -379,21 +403,21 @@ pub(crate) async fn api_handler_task(mut api: Receiver<Request>) {
 					// Always retry for subxt errors (most of them are transient).
 					let _ = connection_pool.remove(&request.url);
 					tokio::time::sleep(std::time::Duration::from_millis(crate::core::RETRY_DELAY_MS)).await;
-					continue;
+					continue
 				},
 				Err(Error::DecodeExtrinsicError) => {
 					error!("Decoding extrinsic failed");
 					// Always retry for subxt errors (most of them are transient).
 					let _ = connection_pool.remove(&request.url);
 					tokio::time::sleep(std::time::Duration::from_millis(crate::core::RETRY_DELAY_MS)).await;
-					continue;
+					continue
 				},
 			};
 
 			// We only break in the happy case.
 			let _ = request.response_sender.send(response);
 			timeout_task.abort();
-			break;
+			break
 		}
 	}
 }
@@ -439,14 +463,14 @@ fn decode_extrinsic(data: &mut &[u8]) -> std::result::Result<SubxtCall, DecodeEx
 	//   - extrinsic data
 	let _expected_length: Compact<u32> = Decode::decode(data).map_err(DecodeExtrinsicError::CodecError)?;
 	if data.is_empty() {
-		return Err(DecodeExtrinsicError::EarlyEof);
+		return Err(DecodeExtrinsicError::EarlyEof)
 	}
 
 	let is_signed = data[0] & 0b1000_0000 != 0;
 	let version = data[0] & 0b0111_1111;
 	*data = &data[1..];
 	if is_signed || version != 4 {
-		return Err(DecodeExtrinsicError::Unsupported);
+		return Err(DecodeExtrinsicError::Unsupported)
 	}
 
 	SubxtCall::decode(data).map_err(DecodeExtrinsicError::CodecError)
@@ -543,7 +567,25 @@ async fn subxt_get_hrmp_channels(
 		.hrmp_ingress_channels_index(&Id(para_id), Some(block_hash))
 		.await
 		.map_err(Error::SubxtError)?;
-	Ok(Response::HRMPChannels(hrmp_channels.into_iter().map(|id| id.0).collect()))
+	Ok(Response::HRMPInboundChannels(hrmp_channels.into_iter().map(|id| id.0).collect()))
+}
+
+async fn subxt_get_hrmp_content(
+	api: &polkadot::RuntimeApi<DefaultConfig, PolkadotExtrinsicParams<DefaultConfig>>,
+	block_hash: H256,
+	para_id: u32,
+	sender: u32,
+) -> Result {
+	use crate::core::api::subxt_wrapper::subxt_runtime_types::polkadot_parachain::primitives::{HrmpChannelId, Id};
+
+	let id = HrmpChannelId { sender: Id(sender), recipient: Id(para_id) };
+	let hrmp_content = api
+		.storage()
+		.hrmp()
+		.hrmp_channel_contents(&id, Some(block_hash))
+		.await
+		.map_err(Error::SubxtError)?;
+	Ok(Response::HRMPInboundContent(hrmp_content.into_iter().map(|hrmp_content| hrmp_content.data).collect()))
 }
 
 fn subxt_extract_parainherent(block: &subxt::rpc::ChainBlock<DefaultConfig>) -> Result {

--- a/src/pc/tracker.rs
+++ b/src/pc/tracker.rs
@@ -550,11 +550,13 @@ impl SubxtTracker {
 			writeln!(f, "\t👉 Inbound HRMP messages, received {} bytes in total", total)?;
 
 			for (peer_parachain, channel) in &self.inbound_hrmp_channels {
-				writeln!(
-					f,
-					"\t\t📩 From parachain: {}, {} bytes / {} max",
-					peer_parachain, channel.total_size, channel.max_message_size
-				)?;
+				if channel.total_size > 0 {
+					writeln!(
+						f,
+						"\t\t📩 From parachain: {}, {} bytes / {} max",
+						peer_parachain, channel.total_size, channel.max_message_size
+					)?;
+				}
 			}
 		}
 
@@ -564,11 +566,13 @@ impl SubxtTracker {
 			writeln!(f, "\t👈 Outbound HRMP messages, sent {} bytes in total", total)?;
 
 			for (peer_parachain, channel) in &self.outbound_hrmp_channels {
-				writeln!(
-					f,
-					"\t\t📩 To parachain: {}, {} bytes / {} max",
-					peer_parachain, channel.total_size, channel.max_message_size
-				)?;
+				if channel.total_size > 0 {
+					writeln!(
+						f,
+						"\t\t📩 To parachain: {}, {} bytes / {} max",
+						peer_parachain, channel.total_size, channel.max_message_size
+					)?;
+				}
 			}
 		}
 

--- a/src/pc/tracker.rs
+++ b/src/pc/tracker.rs
@@ -96,7 +96,7 @@ pub struct SubxtTracker {
 impl Display for SubxtTracker {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		if self.current_relay_block.is_none() {
-			return writeln!(f, "{}", "No relay block processed".to_string().bold().red(),);
+			return writeln!(f, "{}", "No relay block processed".to_string().bold().red(),)
 		}
 		self.display_bitfield_propagation(f)?;
 
@@ -301,13 +301,13 @@ impl SubxtTracker {
 
 		// If a candidate was backed in this relay block, we don't need to process availability now.
 		if candidate_backed {
-			return;
+			return
 		}
 
 		if self.current_candidate.candidate.is_none() {
 			// If no candidate is being backed reset the state to `Idle`.
 			self.current_candidate.state = ParachainBlockState::Idle;
-			return;
+			return
 		}
 
 		// We only process availability if our parachain is assigned to an availability core.
@@ -455,9 +455,9 @@ impl SubxtTracker {
 			// If `max_av_bits` is not set do not check for bitfield propagation.
 			// Usually this happens at startup, when we miss a core assignment and we do not update
 			// availability before calling this `fn`.
-			if self.current_candidate.max_av_bits > 0
-				&& self.current_candidate.state != ParachainBlockState::Idle
-				&& self.current_candidate.bitfield_count <= (self.current_candidate.max_av_bits / 3) * 2
+			if self.current_candidate.max_av_bits > 0 &&
+				self.current_candidate.state != ParachainBlockState::Idle &&
+				self.current_candidate.bitfield_count <= (self.current_candidate.max_av_bits / 3) * 2
 			{
 				writeln!(
 					f,
@@ -591,8 +591,8 @@ impl SubxtTracker {
 			self.display_disputes(f)?;
 		}
 
-		if self.inbound_hrmp_channels.values().any(|channel| channel.total_size > 0)
-			|| self.outbound_hrmp_channels.values().any(|channel| channel.total_size > 0)
+		if self.inbound_hrmp_channels.values().any(|channel| channel.total_size > 0) ||
+			self.outbound_hrmp_channels.values().any(|channel| channel.total_size > 0)
 		{
 			self.display_hrmp(f)?;
 		}

--- a/src/pc/tracker.rs
+++ b/src/pc/tracker.rs
@@ -96,7 +96,7 @@ pub struct SubxtTracker {
 impl Display for SubxtTracker {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		if self.current_relay_block.is_none() {
-			return writeln!(f, "{}", "No relay block processed".to_string().bold().red(),)
+			return writeln!(f, "{}", "No relay block processed".to_string().bold().red(),);
 		}
 		self.display_bitfield_propagation(f)?;
 
@@ -301,13 +301,13 @@ impl SubxtTracker {
 
 		// If a candidate was backed in this relay block, we don't need to process availability now.
 		if candidate_backed {
-			return
+			return;
 		}
 
 		if self.current_candidate.candidate.is_none() {
 			// If no candidate is being backed reset the state to `Idle`.
 			self.current_candidate.state = ParachainBlockState::Idle;
-			return
+			return;
 		}
 
 		// We only process availability if our parachain is assigned to an availability core.
@@ -455,9 +455,9 @@ impl SubxtTracker {
 			// If `max_av_bits` is not set do not check for bitfield propagation.
 			// Usually this happens at startup, when we miss a core assignment and we do not update
 			// availability before calling this `fn`.
-			if self.current_candidate.max_av_bits > 0 &&
-				self.current_candidate.state != ParachainBlockState::Idle &&
-				self.current_candidate.bitfield_count <= (self.current_candidate.max_av_bits / 3) * 2
+			if self.current_candidate.max_av_bits > 0
+				&& self.current_candidate.state != ParachainBlockState::Idle
+				&& self.current_candidate.bitfield_count <= (self.current_candidate.max_av_bits / 3) * 2
 			{
 				writeln!(
 					f,
@@ -563,7 +563,7 @@ impl SubxtTracker {
 		if total > 0 {
 			writeln!(f, "\t👈 Outbound HRMP messages, sent {} bytes in total", total)?;
 
-			for (peer_parachain, channel) in &self.inbound_hrmp_channels {
+			for (peer_parachain, channel) in &self.outbound_hrmp_channels {
 				writeln!(
 					f,
 					"\t\t📩 To parachain: {}, {} bytes / {} max",
@@ -591,8 +591,8 @@ impl SubxtTracker {
 			self.display_disputes(f)?;
 		}
 
-		if self.inbound_hrmp_channels.values().any(|channel| channel.total_size > 0) ||
-			self.outbound_hrmp_channels.values().any(|channel| channel.total_size > 0)
+		if self.inbound_hrmp_channels.values().any(|channel| channel.total_size > 0)
+			|| self.outbound_hrmp_channels.values().any(|channel| channel.total_size > 0)
 		{
 			self.display_hrmp(f)?;
 		}


### PR DESCRIPTION
It might be useful to debug messages in the introspector. As the first step, I would suggest to add these fuctions to the parachains commander and then, probably, to the collector.

- [x] Inspect inbound HRMP
- [x] Inspect outbound HRMP
- [ ] Inspect UMP/DMP

Example:

```
2022-11-23T15:41:00.005000000Z +6002ms [#12] CANDIDATE BACKED
	💜 Candidate hash: 0x44b136826f6ea3cc1d1a92059a65d5eecd795b643c44fa3bc5fa4b30923b99b6
	🔗 Relay block hash: 0x3254d1eb7ca142a11b89755399dd76554b7e5752cc47fa6226f8b4895fbbd440
	👊 Disputes tracked
		👍 Candidate: 0x3d4f8a76b3c0ee1b809972df6510ab3de47e272260bfdbdfd9bbc14c2e3410fc, resolved valid; voted for: 6; voted against: 1
			👹 Validator voted against supermajority: idx: 3, address: 5HKPmK9GYtE1PSLsS1qiYU9xQ9Si1NcEhdeCq9sw5bqu4ns8
	👉 Inbound HRMP messages, received 4096 bytes in total
		📩 From parachain: 1002, 4096 bytes
	👈 Outbound HRMP messages, sent 4096 bytes in total
		📩 To parachain: 1002, 4096 bytes
	🥝 Availability core OCCUPIED
```