### PR TITLE
Implement subscribe mode feature

### DIFF
--- a/src/block_time/mod.rs
+++ b/src/block_time/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::core::{api::ApiService, EventConsumerInit, RecordsStorageConfig, SubxtEvent};
+use crate::core::{api::ApiService, EventConsumerInit, RecordsStorageConfig, SubxtEvent, SubxtSubscriptionMode};
 use clap::Parser;
 use colored::Colorize;
 use crossterm::{
@@ -49,6 +49,9 @@ pub(crate) struct BlockTimeOptions {
 	/// Mode of running - CLI/Prometheus.
 	#[clap(subcommand)]
 	mode: BlockTimeMode,
+	/// Defines subscription mode
+	#[clap(short = 's', long = "subscribe-mode", default_value_t, value_enum)]
+	pub subscribe_mode: SubxtSubscriptionMode,
 }
 
 #[derive(Clone, Debug, Parser, Default)]

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -33,7 +33,7 @@ mod ws;
 
 use crate::core::{
 	ApiService, EventConsumerInit, RecordTime, RecordsStorageConfig, StorageEntry, StorageInfo, SubxtCandidateEvent,
-	SubxtCandidateEventType, SubxtDispute, SubxtDisputeResult, SubxtEvent,
+	SubxtCandidateEventType, SubxtDispute, SubxtDisputeResult, SubxtEvent, SubxtSubscriptionMode,
 };
 use candidate_record::*;
 use color_eyre::eyre::eyre;
@@ -52,6 +52,9 @@ pub(crate) struct CollectorOptions {
 	/// WS listen address to bind to
 	#[clap(short = 'l', long = "listen", default_value = "0.0.0.0:3030")]
 	listen_addr: SocketAddr,
+	/// Defines subscription mode
+	#[clap(short = 's', long = "subscribe-mode", default_value_t, value_enum)]
+	pub subscribe_mode: SubxtSubscriptionMode,
 }
 
 impl From<CollectorOptions> for WebSocketListenerConfig {

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -53,7 +53,7 @@ pub(crate) struct CollectorOptions {
 	#[clap(short = 'l', long = "listen", default_value = "0.0.0.0:3030")]
 	listen_addr: SocketAddr,
 	/// Defines subscription mode
-	#[clap(short = 's', long = "subscribe-mode", default_value_t, value_enum)]
+	#[clap(short = 's', long = "subscribe-to", default_value_t, value_enum)]
 	pub subscribe_mode: SubxtSubscriptionMode,
 }
 

--- a/src/core/subxt_subscription.rs
+++ b/src/core/subxt_subscription.rs
@@ -225,7 +225,7 @@ impl SubxtWrapper {
 // Subxt does not export this type but it is needed to specify future output
 type BlockStream<T> = Pin<Box<dyn Stream<Item = Result<T, Error>> + Send>>;
 
-// Process subscription to a specific block types (e.g. all, best, finalized) and returns `true`
+// Process subscription to a specific block types (e.g. best, finalized) and returns `true`
 // if a caller's loop should be terminated.
 async fn process_subscription_or_stop<Sub, Client>(
 	update_channel: &Sender<SubxtEvent>,

--- a/src/core/subxt_subscription.rs
+++ b/src/core/subxt_subscription.rs
@@ -183,27 +183,24 @@ impl SubxtWrapper {
 				Ok(api) => {
 					info!("[{}] Connected", url);
 					let ret = match subscribe_mode {
-						SubxtSubscriptionMode::SubscribeAll => {
+						SubxtSubscriptionMode::SubscribeAll =>
 							process_subscription_or_stop(&update_channel, api.blocks().subscribe_all(), url.as_str())
-								.await
-						},
-						SubxtSubscriptionMode::SubscribeBest => {
+								.await,
+						SubxtSubscriptionMode::SubscribeBest =>
 							process_subscription_or_stop(&update_channel, api.blocks().subscribe_best(), url.as_str())
-								.await
-						},
-						SubxtSubscriptionMode::SubscribeFinalized => {
+								.await,
+						SubxtSubscriptionMode::SubscribeFinalized =>
 							process_subscription_or_stop(
 								&update_channel,
 								api.blocks().subscribe_finalized(),
 								url.as_str(),
 							)
-							.await
-						},
+							.await,
 					};
 
 					if ret {
 						// Subscription has decided to stop
-						return;
+						return
 					}
 				},
 				Err(err) => {

--- a/src/core/subxt_subscription.rs
+++ b/src/core/subxt_subscription.rs
@@ -86,7 +86,7 @@ pub enum SubxtSubscriptionMode {
 
 impl Default for SubxtSubscriptionMode {
 	fn default() -> Self {
-		SubxtSubscriptionMode::All
+		SubxtSubscriptionMode::Best
 	}
 }
 

--- a/src/core/subxt_subscription.rs
+++ b/src/core/subxt_subscription.rs
@@ -77,16 +77,16 @@ pub enum SubxtDisputeResult {
 #[derive(strum::Display, Debug, Clone, Copy, clap::ValueEnum)]
 pub enum SubxtSubscriptionMode {
 	/// Subscribe to all blocks
-	SubscribeAll,
+	All,
 	/// Subscribe to the best chain
-	SubscribeBest,
+	Best,
 	/// Subscribe to finalized blocks
-	SubscribeFinalized,
+	Finalized,
 }
 
 impl Default for SubxtSubscriptionMode {
 	fn default() -> Self {
-		SubxtSubscriptionMode::SubscribeAll
+		SubxtSubscriptionMode::All
 	}
 }
 
@@ -183,13 +183,13 @@ impl SubxtWrapper {
 				Ok(api) => {
 					info!("[{}] Connected", url);
 					let ret = match subscribe_mode {
-						SubxtSubscriptionMode::SubscribeAll =>
+						SubxtSubscriptionMode::All =>
 							process_subscription_or_stop(&update_channel, api.blocks().subscribe_all(), url.as_str())
 								.await,
-						SubxtSubscriptionMode::SubscribeBest =>
+						SubxtSubscriptionMode::Best =>
 							process_subscription_or_stop(&update_channel, api.blocks().subscribe_best(), url.as_str())
 								.await,
-						SubxtSubscriptionMode::SubscribeFinalized =>
+						SubxtSubscriptionMode::Finalized =>
 							process_subscription_or_stop(
 								&update_channel,
 								api.blocks().subscribe_finalized(),

--- a/src/core/subxt_subscription.rs
+++ b/src/core/subxt_subscription.rs
@@ -76,8 +76,6 @@ pub enum SubxtDisputeResult {
 /// How to subscribe to subxt blocks
 #[derive(strum::Display, Debug, Clone, Copy, clap::ValueEnum)]
 pub enum SubxtSubscriptionMode {
-	/// Subscribe to all blocks
-	All,
 	/// Subscribe to the best chain
 	Best,
 	/// Subscribe to finalized blocks
@@ -183,9 +181,6 @@ impl SubxtWrapper {
 				Ok(api) => {
 					info!("[{}] Connected", url);
 					let ret = match subscribe_mode {
-						SubxtSubscriptionMode::All =>
-							process_subscription_or_stop(&update_channel, api.blocks().subscribe_all(), url.as_str())
-								.await,
 						SubxtSubscriptionMode::Best =>
 							process_subscription_or_stop(&update_channel, api.blocks().subscribe_best(), url.as_str())
 								.await,

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,7 +78,7 @@ async fn main() -> color_eyre::Result<()> {
 
 	match opts.command {
 		Command::Collector(opts) => {
-			let mut core = core::SubxtWrapper::new(opts.nodes.clone());
+			let mut core = core::SubxtWrapper::new(opts.nodes.clone(), opts.subscribe_mode);
 			let collector_consumer_init = core.create_consumer();
 
 			match collector::run(opts, collector_consumer_init).await {
@@ -87,7 +87,7 @@ async fn main() -> color_eyre::Result<()> {
 			}
 		},
 		Command::BlockTimeMonitor(opts) => {
-			let mut core = core::SubxtWrapper::new(opts.nodes.clone());
+			let mut core = core::SubxtWrapper::new(opts.nodes.clone(), opts.subscribe_mode);
 			let block_time_consumer_init = core.create_consumer();
 
 			match block_time::BlockTimeMonitor::new(opts, block_time_consumer_init)?.run().await {
@@ -114,7 +114,7 @@ async fn main() -> color_eyre::Result<()> {
 			kvdb::introspect_kvdb(opts).await?;
 		},
 		Command::ParachainCommander(opts) => {
-			let mut core = core::SubxtWrapper::new(vec![opts.node.clone()]);
+			let mut core = core::SubxtWrapper::new(vec![opts.node.clone()], opts.subscribe_mode);
 			let consumer_init = core.create_consumer();
 
 			match pc::ParachainCommander::new(opts, consumer_init)?.run().await {

--- a/src/pc/mod.rs
+++ b/src/pc/mod.rs
@@ -27,7 +27,9 @@
 //! The CLI interface is useful for debugging/diagnosing issues with the parachain block pipeline.
 //! Soon: CI integration also supported via Prometheus metrics exporting.
 
-use crate::core::{api::ApiService, EventConsumerInit, RecordsStorageConfig, SubxtDisputeResult, SubxtEvent};
+use crate::core::{
+	api::ApiService, EventConsumerInit, RecordsStorageConfig, SubxtDisputeResult, SubxtEvent, SubxtSubscriptionMode,
+};
 use std::collections::HashMap;
 
 use clap::Parser;
@@ -56,6 +58,9 @@ pub(crate) struct ParachainCommanderOptions {
 	/// Run for a number of blocks then stop.
 	#[clap(name = "blocks", long)]
 	block_count: Option<u32>,
+	/// Defines subscription mode
+	#[clap(short = 's', long = "subscribe-mode", default_value_t, value_enum)]
+	pub subscribe_mode: SubxtSubscriptionMode,
 }
 
 pub(crate) struct ParachainCommander {


### PR DESCRIPTION
This PR implements different subscribe modes:

```
  -s, --subscribe-mode <SUBSCRIBE_MODE>
          Defines subscription mode

          [default: subscribe-all]

          Possible values:
          - subscribe-all:       Subscribe to all blocks
          - subscribe-best:      Subscribe to the best chain
          - subscribe-finalized: Subscribe to finalized blocks
```

Closes #180 