### PR TITLE
Implement Prometheus endpoint for the parachain commander

### DIFF
--- a/src/block_time/mod.rs
+++ b/src/block_time/mod.rs
@@ -27,6 +27,7 @@ use prometheus_endpoint::{HistogramVec, Registry};
 use std::{
 	collections::VecDeque,
 	io::{stdout, Write},
+	net::ToSocketAddrs,
 	sync::{Arc, Mutex},
 };
 use subxt::ext::sp_core::H256;
@@ -68,8 +69,11 @@ pub(crate) struct BlockTimeCliOptions {
 #[derive(Clone, Debug, Parser, Default)]
 #[clap(rename_all = "kebab-case")]
 pub(crate) struct BlockTimePrometheusOptions {
-	/// Prometheus endpoint port.
-	#[clap(long, default_value = "65432")]
+	/// Address to bind Prometheus listener
+	#[clap(short = 'a', long = "address", default_value = "127.0.0.1")]
+	address: String,
+	/// Port to bind Prometheus listener
+	#[clap(short = 'p', long = "port", default_value = "65432")]
 	port: u16,
 }
 
@@ -101,12 +105,10 @@ impl BlockTimeMonitor {
 				let prometheus_registry = Registry::new_custom(Some("introspector".into()), None)?;
 				let block_time_metric = Some(register_metric(&prometheus_registry));
 
-				let socket_addr = std::net::SocketAddr::new(
-					std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)),
-					prometheus_opts.port,
-				);
-				tokio::spawn(prometheus_endpoint::init_prometheus(socket_addr, prometheus_registry));
-
+				let socket_addr_str = format!("{}:{}", prometheus_opts.address, prometheus_opts.port);
+				socket_addr_str.to_socket_addrs()?.for_each(|addr| {
+					tokio::spawn(prometheus_endpoint::init_prometheus(addr, prometheus_registry.clone()));
+				});
 				Ok(BlockTimeMonitor { values, opts, block_time_metric, endpoints, consumer_config, api_service })
 			},
 			BlockTimeMode::Cli(_) =>

--- a/src/block_time/mod.rs
+++ b/src/block_time/mod.rs
@@ -70,7 +70,7 @@ pub(crate) struct BlockTimeCliOptions {
 #[clap(rename_all = "kebab-case")]
 pub(crate) struct BlockTimePrometheusOptions {
 	/// Address to bind Prometheus listener
-	#[clap(short = 'a', long = "address", default_value = "127.0.0.1")]
+	#[clap(short = 'a', long = "address", default_value = "0.0.0.0")]
 	address: String,
 	/// Port to bind Prometheus listener
 	#[clap(short = 'p', long = "port", default_value = "65432")]

--- a/src/kvdb/prometheus.rs
+++ b/src/kvdb/prometheus.rs
@@ -26,7 +26,7 @@ use std::net::ToSocketAddrs;
 #[clap(rename_all = "kebab-case")]
 pub struct KvdbPrometheusOptions {
 	/// Address to bind Prometheus listener
-	#[clap(short = 'a', long = "address", default_value = "127.0.0.1")]
+	#[clap(short = 'a', long = "address", default_value = "0.0.0.0")]
 	address: String,
 	/// Port to bind Prometheus listener
 	#[clap(short = 'p', long = "port", default_value = "65432")]

--- a/src/pc/mod.rs
+++ b/src/pc/mod.rs
@@ -76,7 +76,7 @@ pub(crate) struct ParachainCommanderOptions {
 	/// Defines subscription mode
 	#[clap(short = 's', long = "subscribe-mode", default_value_t, value_enum)]
 	pub subscribe_mode: SubxtSubscriptionMode,
-	/// Mode of running - CLI/Prometheus.
+	/// Mode of running - CLI/Prometheus. Default or no subcommand means `CLI` mode.
 	#[clap(subcommand)]
 	mode: Option<ParachainCommanderMode>,
 }

--- a/src/pc/mod.rs
+++ b/src/pc/mod.rs
@@ -34,31 +34,51 @@ use clap::Parser;
 use color_eyre::owo_colors::OwoColorize;
 use crossterm::style::Stylize;
 use log::info;
-use std::{collections::HashMap, time::Duration};
+use std::{collections::HashMap, default::Default, time::Duration};
 use subxt::ext::sp_core::H256;
 use tokio::sync::mpsc::{error::TryRecvError, Receiver};
 
 mod progress;
+pub(crate) mod prometheus;
 pub(crate) mod stats;
 pub(crate) mod tracker;
 
+use prometheus::{Metrics, ParachainCommanderPrometheusOptions};
 use tracker::ParachainBlockTracker;
+
+#[derive(Clone, Debug, Parser)]
+#[clap(rename_all = "kebab-case")]
+pub(crate) enum ParachainCommanderMode {
+	/// CLI chart mode.
+	Cli,
+	/// Prometheus endpoint mode.
+	Prometheus(ParachainCommanderPrometheusOptions),
+}
+
+impl Default for ParachainCommanderMode {
+	fn default() -> Self {
+		ParachainCommanderMode::Cli
+	}
+}
 
 #[derive(Clone, Debug, Parser)]
 #[clap(rename_all = "kebab-case")]
 pub(crate) struct ParachainCommanderOptions {
 	/// Web-Socket URLs of a relay chain node.
-	#[clap(name = "ws", long, value_delimiter = ',', default_value = "wss://rpc.polkadot.io:443")]
+	#[clap(name = "ws", global(true), long, value_delimiter = ',', default_value = "wss://rpc.polkadot.io:443")]
 	pub node: String,
 	/// Parachain id.
-	#[clap(long)]
+	#[clap(long, global(true))]
 	para_id: u32,
 	/// Run for a number of blocks then stop.
-	#[clap(name = "blocks", long)]
+	#[clap(name = "blocks", long, global(true))]
 	block_count: Option<u32>,
 	/// Defines subscription mode
-	#[clap(short = 's', long = "subscribe-mode", default_value_t, value_enum)]
+	#[clap(short = 's', long = "subscribe-mode", default_value_t, value_enum, global(true))]
 	pub subscribe_mode: SubxtSubscriptionMode,
+	/// Mode of running - CLI/Prometheus.
+	#[clap(subcommand)]
+	mode: Option<ParachainCommanderMode>,
 }
 
 pub(crate) struct ParachainCommander {
@@ -66,6 +86,7 @@ pub(crate) struct ParachainCommander {
 	node: String,
 	consumer_config: EventConsumerInit<SubxtEvent>,
 	api_service: ApiService<H256>,
+	metrics: Metrics,
 }
 
 impl ParachainCommander {
@@ -77,12 +98,20 @@ impl ParachainCommander {
 		let api_service = ApiService::new_with_storage(RecordsStorageConfig { max_blocks: 1000 });
 		let node = opts.node.clone();
 
-		Ok(ParachainCommander { opts, node, consumer_config, api_service })
+		Ok(ParachainCommander { opts, node, consumer_config, api_service, metrics: Default::default() })
 	}
 
 	// Spawn the UI and subxt tasks and return their futures.
-	pub(crate) async fn run(self) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>> {
+	pub(crate) async fn run(mut self) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>> {
 		let consumer_channels: Vec<Receiver<SubxtEvent>> = self.consumer_config.into();
+
+		let mut output_futures = vec![];
+
+		if let Some(ParachainCommanderMode::Prometheus(ref prometheus_opts)) = self.opts.mode {
+			let (metrics, endpoint_future) = prometheus::run_prometheus_endpoint(prometheus_opts).await?;
+			output_futures.extend(endpoint_future.into_iter());
+			self.metrics = metrics;
+		}
 
 		let watcher_future = tokio::spawn(Self::watch_node(
 			self.opts.clone(),
@@ -90,9 +119,12 @@ impl ParachainCommander {
 			// There is only one update channel (we only follow one RPC node).
 			consumer_channels.into_iter().next().unwrap(),
 			self.api_service,
+			self.metrics,
 		));
 
-		Ok(vec![watcher_future])
+		output_futures.push(watcher_future);
+
+		Ok(output_futures)
 	}
 
 	// This is the main loop for our subxt subscription.
@@ -102,6 +134,7 @@ impl ParachainCommander {
 		url: String,
 		mut consumer_config: Receiver<SubxtEvent>,
 		api_service: ApiService<H256>,
+		metrics: Metrics,
 	) {
 		// The subxt API request executor.
 		let executor = api_service.subxt();
@@ -130,8 +163,10 @@ impl ParachainCommander {
 				Ok(event) => match event {
 					SubxtEvent::NewHead(hash) => {
 						tracker.inject_disputes_events(&recent_disputes_concluded);
-						if let Some(progress) = tracker.progress() {
-							println!("{}", progress);
+						if let Some(progress) = tracker.progress(&metrics) {
+							if matches!(opts.mode, Some(ParachainCommanderMode::Cli)) {
+								println!("{}", progress);
+							}
 						}
 						tracker.maybe_reset_state();
 						recent_disputes_concluded.clear();
@@ -188,6 +223,10 @@ impl ParachainCommander {
 		}
 
 		let stats = tracker.summary();
-		print!("{}", stats);
+		if matches!(opts.mode, Some(ParachainCommanderMode::Cli)) {
+			print!("{}", stats);
+		} else {
+			info!("{}", stats);
+		}
 	}
 }

--- a/src/pc/mod.rs
+++ b/src/pc/mod.rs
@@ -65,16 +65,16 @@ impl Default for ParachainCommanderMode {
 #[clap(rename_all = "kebab-case")]
 pub(crate) struct ParachainCommanderOptions {
 	/// Web-Socket URLs of a relay chain node.
-	#[clap(name = "ws", global(true), long, value_delimiter = ',', default_value = "wss://rpc.polkadot.io:443")]
+	#[clap(name = "ws", long, value_delimiter = ',', default_value = "wss://rpc.polkadot.io:443")]
 	pub node: String,
 	/// Parachain id.
-	#[clap(long, global(true))]
+	#[clap(long)]
 	para_id: u32,
 	/// Run for a number of blocks then stop.
-	#[clap(name = "blocks", long, global(true))]
+	#[clap(name = "blocks", long)]
 	block_count: Option<u32>,
 	/// Defines subscription mode
-	#[clap(short = 's', long = "subscribe-mode", default_value_t, value_enum, global(true))]
+	#[clap(short = 's', long = "subscribe-mode", default_value_t, value_enum)]
 	pub subscribe_mode: SubxtSubscriptionMode,
 	/// Mode of running - CLI/Prometheus.
 	#[clap(subcommand)]

--- a/src/pc/mod.rs
+++ b/src/pc/mod.rs
@@ -108,9 +108,7 @@ impl ParachainCommander {
 		let mut output_futures = vec![];
 
 		if let Some(ParachainCommanderMode::Prometheus(ref prometheus_opts)) = self.opts.mode {
-			let (metrics, endpoint_future) = prometheus::run_prometheus_endpoint(prometheus_opts).await?;
-			output_futures.extend(endpoint_future.into_iter());
-			self.metrics = metrics;
+			self.metrics = prometheus::run_prometheus_endpoint(prometheus_opts).await?;
 		}
 
 		let watcher_future = tokio::spawn(Self::watch_node(

--- a/src/pc/prometheus.rs
+++ b/src/pc/prometheus.rs
@@ -192,7 +192,7 @@ fn register_metrics(registry: &Registry) -> Result<Metrics> {
 		)?,
 		resolution_time: prometheus_endpoint::register(
 			HistogramVec::new(
-				HistogramOpts::new("pc_block_time", "Block time for parachain measurements for relay parent blocks")
+				HistogramOpts::new("pc_disputed_resolve_time", "Dispute resolution time in relay parent blocks")
 					.buckets(HISTOGRAM_TIME_BUCKETS.into()),
 				&["parachain_id"],
 			)?,

--- a/src/pc/prometheus.rs
+++ b/src/pc/prometheus.rs
@@ -64,7 +64,7 @@ struct MetricsInner {
 	low_bitfields_count: IntCounterVec,
 	/// Number of bitfields being set
 	bitfields: IntGaugeVec,
-	/// Average included time in relay parent blocks
+	/// Average candidate inclusion time measured in relay chain blocks.
 	included_times: HistogramVec,
 }
 
@@ -216,7 +216,7 @@ fn register_metrics(registry: &Registry) -> Result<Metrics> {
 		disputes_stats,
 		block_times: prometheus_endpoint::register(
 			HistogramVec::new(
-				HistogramOpts::new("pc_block_time", "Block time for parachain measurements for relay parent blocks")
+				HistogramOpts::new("pc_block_time", "Relay chain block time measured in seconds")
 					.buckets(HISTOGRAM_TIME_BUCKETS.into()),
 				&["parachain_id"],
 			)?,
@@ -224,14 +224,14 @@ fn register_metrics(registry: &Registry) -> Result<Metrics> {
 		)?,
 		slow_avail_count: prometheus_endpoint::register(
 			IntCounterVec::new(
-				Opts::new("pc_slow_available_count", "Number of slow availability events"),
+				Opts::new("pc_slow_available_count", "Number of slow availability events. We consider it slow when the relay chain block bitfield entries amounts to less than 2/3 one bits for the availability core to which the parachain is assigned"),
 				&["parachain_id"],
 			)?,
 			registry,
 		)?,
 		low_bitfields_count: prometheus_endpoint::register(
 			IntCounterVec::new(
-				Opts::new("pc_low_bitfields_count", "Number of low bitfields events"),
+				Opts::new("pc_low_bitfields_count", "Number of low bitfields count events. This happens when a block author received the signed bitfields from less than 2/3 of the para validators"),
 				&["parachain_id"],
 			)?,
 			registry,
@@ -242,7 +242,7 @@ fn register_metrics(registry: &Registry) -> Result<Metrics> {
 		)?,
 		included_times: prometheus_endpoint::register(
 			HistogramVec::new(
-				HistogramOpts::new("pc_included_time", "Average included time in relay parent blocks")
+				HistogramOpts::new("pc_included_time", "Parachain block time measured in relay chain blocks.")
 					.buckets(HISTOGRAM_TIME_BUCKETS.into()),
 				&["parachain_id"],
 			)?,

--- a/src/pc/prometheus.rs
+++ b/src/pc/prometheus.rs
@@ -1,0 +1,257 @@
+// Copyright 2022 Parity Technologies (UK) Ltd.
+// This file is part of polkadot-introspector.
+//
+// polkadot-introspector is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// polkadot-introspector is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::pc::tracker::DisputesOutcome;
+use clap::Parser;
+use color_eyre::Result;
+use prometheus_endpoint::{
+	prometheus::{HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts},
+	Registry,
+};
+use std::net::ToSocketAddrs;
+
+#[derive(Clone, Debug, Parser, Default)]
+#[clap(rename_all = "kebab-case")]
+pub struct ParachainCommanderPrometheusOptions {
+	/// Address to bind Prometheus listener
+	#[clap(short = 'a', long = "address", default_value = "0.0.0.0")]
+	address: String,
+	/// Port to bind Prometheus listener
+	#[clap(short = 'p', long = "port", default_value = "65432")]
+	port: u16,
+}
+
+#[derive(Clone)]
+struct DisputesMetrics {
+	/// Number of candidates disputed.
+	disputed_count: IntCounterVec,
+	concluded_valid: IntCounterVec,
+	concluded_invalid: IntCounterVec,
+	/// Average count of validators that voted against supermajority
+	/// Average resolution time in blocks
+	resolution_time: HistogramVec,
+}
+
+#[derive(Clone)]
+struct MetricsInner {
+	/// Number of backed candidates.
+	backed_count: IntCounterVec,
+	/// Number of skipped slots, where no candidate was backed and availability core
+	/// was free.
+	skipped_slots: IntCounterVec,
+	/// Number of candidates included.
+	included_count: IntCounterVec,
+	/// Disputes stats
+	disputes_stats: DisputesMetrics,
+	/// Block time measurements for relay parent blocks
+	block_times: HistogramVec,
+	/// Number of slow availability events.
+	slow_avail_count: IntCounterVec,
+	/// Number of low bitfield propagation events.
+	low_bitfields_count: IntCounterVec,
+	/// Number of bitfields being set
+	bitfields: IntGaugeVec,
+	/// Average included time in relay parent blocks
+	included_times: HistogramVec,
+}
+
+/// Parachain commander prometheus metrics
+#[derive(Default, Clone)]
+pub struct Metrics(Option<MetricsInner>);
+
+const HISTOGRAM_TIME_BUCKETS: &[f64] =
+	&[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 15.0, 25.0, 35.0, 50.0];
+
+impl Metrics {
+	pub(crate) fn on_backed(&self, para_id: u32) {
+		if let Some(metrics) = &self.0 {
+			metrics.backed_count.with_label_values(&[&para_id.to_string()[..]]).inc();
+		}
+	}
+
+	pub(crate) fn on_block(&self, time: f64, para_id: u32) {
+		if let Some(metrics) = &self.0 {
+			metrics.block_times.with_label_values(&[&para_id.to_string()[..]]).observe(time);
+		}
+	}
+
+	pub(crate) fn on_slow_availability(&self, para_id: u32) {
+		if let Some(metrics) = &self.0 {
+			metrics.slow_avail_count.with_label_values(&[&para_id.to_string()[..]]).inc();
+		}
+	}
+
+	pub(crate) fn on_bitfields(&self, nbitfields: u32, is_low: bool, para_id: u32) {
+		if let Some(metrics) = &self.0 {
+			metrics
+				.bitfields
+				.with_label_values(&[&para_id.to_string()[..]])
+				.set(nbitfields as i64);
+
+			if is_low {
+				metrics.low_bitfields_count.with_label_values(&[&para_id.to_string()[..]]).inc();
+			}
+		}
+	}
+
+	pub(crate) fn on_skipped_slot(&self, para_id: u32) {
+		if let Some(metrics) = &self.0 {
+			metrics.skipped_slots.with_label_values(&[&para_id.to_string()[..]]).inc();
+		}
+	}
+
+	pub(crate) fn on_disputed(&self, dispute_outcome: &DisputesOutcome, para_id: u32) {
+		if let Some(metrics) = &self.0 {
+			let para_str: String = para_id.to_string();
+			metrics.disputes_stats.disputed_count.with_label_values(&[&para_str[..]]).inc();
+
+			if dispute_outcome.voted_for > dispute_outcome.voted_against {
+				metrics.disputes_stats.concluded_valid.with_label_values(&[&para_str[..]]).inc();
+			} else {
+				metrics
+					.disputes_stats
+					.concluded_invalid
+					.with_label_values(&[&para_str[..]])
+					.inc();
+			}
+
+			if let Some(diff) = dispute_outcome.resolve_time {
+				metrics
+					.disputes_stats
+					.resolution_time
+					.with_label_values(&[&para_str[..]])
+					.observe(diff as f64);
+			}
+		}
+	}
+
+	pub(crate) fn on_included(&self, relay_parent_number: u32, previous_included: Option<u32>, para_id: u32) {
+		if let Some(metrics) = &self.0 {
+			let para_str: String = para_id.to_string();
+			metrics.included_count.with_label_values(&[&para_str[..]]).inc();
+
+			if let Some(previous_block_number) = previous_included {
+				metrics
+					.included_times
+					.with_label_values(&[&para_str[..]])
+					.observe(relay_parent_number.saturating_sub(previous_block_number) as f64);
+			}
+		}
+	}
+}
+
+pub async fn run_prometheus_endpoint(
+	prometheus_opts: &ParachainCommanderPrometheusOptions,
+) -> Result<(Metrics, Vec<tokio::task::JoinHandle<()>>)> {
+	let prometheus_registry = Registry::new_custom(Some("introspector".into()), None)?;
+	let metrics = register_metrics(&prometheus_registry)?;
+	let socket_addr_str = format!("{}:{}", prometheus_opts.address, prometheus_opts.port);
+	let mut futures: Vec<tokio::task::JoinHandle<()>> = vec![];
+	for addr in socket_addr_str.to_socket_addrs()? {
+		let prometheus_registry = prometheus_registry.clone();
+		futures.push(tokio::spawn(async move {
+			prometheus_endpoint::init_prometheus(addr, prometheus_registry).await.unwrap()
+		}));
+	}
+
+	Ok((metrics, futures))
+}
+
+fn register_metrics(registry: &Registry) -> Result<Metrics> {
+	let disputes_stats = DisputesMetrics {
+		disputed_count: prometheus_endpoint::register(
+			IntCounterVec::new(Opts::new("pc_disputed_count", "Number of disputed candidates"), &["parachain_id"])?,
+			registry,
+		)?,
+		concluded_valid: prometheus_endpoint::register(
+			IntCounterVec::new(
+				Opts::new("pc_disputed_valid_count", "Number of disputed candidates concluded valid"),
+				&["parachain_id"],
+			)?,
+			registry,
+		)?,
+		concluded_invalid: prometheus_endpoint::register(
+			IntCounterVec::new(
+				Opts::new("pc_disputed_invalid_count", "Number of disputed candidates concluded invalid"),
+				&["parachain_id"],
+			)?,
+			registry,
+		)?,
+		resolution_time: prometheus_endpoint::register(
+			HistogramVec::new(
+				HistogramOpts::new("pc_block_time", "Block time for parachain measurements for relay parent blocks")
+					.buckets(HISTOGRAM_TIME_BUCKETS.into()),
+				&["parachain_id"],
+			)?,
+			registry,
+		)?,
+	};
+	Ok(Metrics(Some(MetricsInner {
+		backed_count: prometheus_endpoint::register(
+			IntCounterVec::new(Opts::new("pc_backed_count", "Number of backed candidates"), &["parachain_id"])?,
+			registry,
+		)?,
+		skipped_slots: prometheus_endpoint::register(
+			IntCounterVec::new(
+				Opts::new(
+					"pc_skipped_slots",
+					"Number of skipped slots, where no candidate was backed and availability core was free",
+				),
+				&["parachain_id"],
+			)?,
+			registry,
+		)?,
+		included_count: prometheus_endpoint::register(
+			IntCounterVec::new(Opts::new("pc_included_count", "Number of candidates included"), &["parachain_id"])?,
+			registry,
+		)?,
+		disputes_stats,
+		block_times: prometheus_endpoint::register(
+			HistogramVec::new(
+				HistogramOpts::new("pc_block_time", "Block time for parachain measurements for relay parent blocks")
+					.buckets(HISTOGRAM_TIME_BUCKETS.into()),
+				&["parachain_id"],
+			)?,
+			registry,
+		)?,
+		slow_avail_count: prometheus_endpoint::register(
+			IntCounterVec::new(
+				Opts::new("pc_slow_available_count", "Number of slow availability events"),
+				&["parachain_id"],
+			)?,
+			registry,
+		)?,
+		low_bitfields_count: prometheus_endpoint::register(
+			IntCounterVec::new(
+				Opts::new("pc_low_bitfields_count", "Number of low bitfields events"),
+				&["parachain_id"],
+			)?,
+			registry,
+		)?,
+		bitfields: prometheus_endpoint::register(
+			IntGaugeVec::new(Opts::new("pc_bitfields_count", "Number of bitfields"), &["parachain_id"]).unwrap(),
+			registry,
+		)?,
+		included_times: prometheus_endpoint::register(
+			HistogramVec::new(
+				HistogramOpts::new("pc_included_time", "Average included time in relay parent blocks")
+					.buckets(HISTOGRAM_TIME_BUCKETS.into()),
+				&["parachain_id"],
+			)?,
+			registry,
+		)?,
+	})))
+}


### PR DESCRIPTION
This PR implements Prometheus mode for the parachain commander tool, allowing to collect metrics about parachain(s) progression. So far, only one parachain is supported, however, that could easily be extended in future.