### PR TITLE
Add CI job to publish description of docker image to hub.docker.com

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,3 +177,20 @@ publish-docker:
     - buildah push --format=v2s2 "$IMAGE_NAME:latest"
   after_script:
     - buildah logout --all
+
+publish-docker-image-description:
+  stage:                           publish
+  <<:                              *kubernetes-env
+  image:                           paritytech/dockerhub-description
+  variables:
+    DOCKER_USERNAME:               $Docker_Hub_User_Parity
+    DOCKER_PASSWORD:               $Docker_Hub_Pass_Parity
+    README_FILEPATH:               $CI_PROJECT_DIR/scripts/ci/dockerfiles/Dockerfile.README.md
+    DOCKERHUB_REPOSITORY:          paritytech/polkadot-introspector
+    SHORT_DESCRIPTION:             "Collection of tools for monitoring and introspection of Substrate based blockchains like Polkadot"
+  rules:
+  - if: $CI_COMMIT_REF_NAME == "master"
+    changes:
+    - scripts/ci/dockerfiles/Dockerfile.README.md
+  script:
+    - cd / && sh entrypoint.sh

--- a/scripts/ci/dockerfiles/Dockerfile.README.md
+++ b/scripts/ci/dockerfiles/Dockerfile.README.md
@@ -1,0 +1,8 @@
+# Polkadot introspector
+
+The introspector is a collection of tools for monitoring and introspection of the Polkadot
+or other substrate based blockchains via a set of tools (for example, subxt). Depending on
+the tool, the data source and output might differ. For examples of how this data can be
+visualised in Grafana, please see the Grafana dashboards section.
+
+### [GitHub](https://github.com/paritytech/polkadot-introspector)


### PR DESCRIPTION
Added CI job to publish Docker image description to [hub.docker.com](https://hub.docker.com/r/paritytech/polkadot-introspector)
Description can be updated in a `scripts/ci/dockerfiles/Dockerfile.README.md` file in a repository root and as soon it will be merged into `master` branch its content will get published to [hub.docker.com](https://hub.docker.com/r/paritytech/polkadot-introspector)

Related https://github.com/paritytech/ci_cd/issues/741