### PR TITLE
Move subscribe-mode to collector

### DIFF
--- a/src/block_time/mod.rs
+++ b/src/block_time/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Parity Technologies (UK) Ltd.
+// Copyright 2023 Parity Technologies (UK) Ltd.
 // This file is part of polkadot-introspector.
 //
 // polkadot-introspector is free software: you can redistribute it and/or modify
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::core::{api::ApiService, EventConsumerInit, RecordsStorageConfig, SubxtEvent, SubxtSubscriptionMode};
+use crate::core::{api::ApiService, EventConsumerInit, RecordsStorageConfig, SubxtEvent};
 use clap::Parser;
 use colored::Colorize;
 use crossterm::{
@@ -261,7 +261,7 @@ impl BlockTimeMonitor {
 			if let Some(event) = consumer_config.recv().await {
 				debug!("New event: {:?}", event);
 				match event {
-					SubxtEvent::NewHead(hash) => {
+					SubxtEvent::NewBestHead(hash) => {
 						let ts = executor.get_block_timestamp(url, Some(hash)).await;
 						let header = executor.get_block_head(url, Some(hash)).await;
 

--- a/src/block_time/mod.rs
+++ b/src/block_time/mod.rs
@@ -16,7 +16,7 @@
 
 use crate::core::{
 	api::ApiService,
-	collector::{new_head_hash, CollectorSubscriptionMode},
+	collector::{new_head_hash, CollectorSubscribeMode},
 	EventConsumerInit, RecordsStorageConfig, SubxtEvent,
 };
 use clap::Parser;
@@ -59,7 +59,7 @@ pub(crate) struct BlockTimeOptions {
 	mode: BlockTimeMode,
 	/// Defines subscription mode
 	#[clap(short = 's', long = "subscribe-mode", default_value_t, value_enum)]
-	pub subscribe_mode: CollectorSubscriptionMode,
+	pub subscribe_mode: CollectorSubscribeMode,
 }
 
 #[derive(Clone, Debug, Parser, Default)]

--- a/src/core/collector/mod.rs
+++ b/src/core/collector/mod.rs
@@ -215,7 +215,7 @@ impl Collector {
 	/// Collects chain events from new head including block events parsing
 	pub async fn collect_chain_events(&mut self, event: &SubxtEvent) -> color_eyre::Result<Vec<ChainEvent>> {
 		match event {
-			SubxtEvent::NewHead(block_hash) => {
+			SubxtEvent::NewBestHead(block_hash) => {
 				let block_hash = *block_hash;
 				let mut chain_events = vec![ChainEvent::NewHead(block_hash)];
 				let block_events = self.executor.get_events(self.endpoint.as_str(), Some(block_hash)).await?;

--- a/src/core/collector/mod.rs
+++ b/src/core/collector/mod.rs
@@ -60,12 +60,12 @@ pub struct CollectorOptions {
 	#[clap(short = 'l', long = "listen")]
 	listen_addr: Option<SocketAddr>,
 	#[clap(short = 's', long = "subscribe-mode", default_value_t, value_enum)]
-	pub subscribe_mode: CollectorSubscriptionMode,
+	pub subscribe_mode: CollectorSubscribeMode,
 }
 
 /// How to subscribe to subxt blocks
 #[derive(strum::Display, Debug, Clone, Copy, clap::ValueEnum, Default)]
-pub enum CollectorSubscriptionMode {
+pub enum CollectorSubscribeMode {
 	/// Subscribe to the best chain
 	Best,
 	/// Subscribe to finalized blocks
@@ -154,7 +154,7 @@ pub struct Collector {
 	broadcast_channels: Vec<BroadcastSender<CollectorUpdateEvent>>,
 	state: CollectorState,
 	executor: RequestExecutor,
-	subscribe_mode: CollectorSubscriptionMode,
+	subscribe_mode: CollectorSubscribeMode,
 }
 
 impl Collector {
@@ -807,10 +807,10 @@ fn get_unix_time_unwrap() -> Duration {
 	SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
 }
 
-pub fn new_head_hash(event: &SubxtEvent, subscribe_mode: CollectorSubscriptionMode) -> Option<&H256> {
+pub fn new_head_hash(event: &SubxtEvent, subscribe_mode: CollectorSubscribeMode) -> Option<&H256> {
 	match (event, subscribe_mode) {
-		(SubxtEvent::NewBestHead(hash), CollectorSubscriptionMode::Best) => Some(hash),
-		(SubxtEvent::NewFinalizedHead(hash), CollectorSubscriptionMode::Finalized) => Some(hash),
+		(SubxtEvent::NewBestHead(hash), CollectorSubscribeMode::Best) => Some(hash),
+		(SubxtEvent::NewFinalizedHead(hash), CollectorSubscribeMode::Finalized) => Some(hash),
 		_ => None,
 	}
 }

--- a/src/core/collector/mod.rs
+++ b/src/core/collector/mod.rs
@@ -59,6 +59,18 @@ pub struct CollectorOptions {
 	/// WS listen address to bind to
 	#[clap(short = 'l', long = "listen")]
 	listen_addr: Option<SocketAddr>,
+	#[clap(short = 's', long = "subscribe-mode", default_value_t, value_enum)]
+	pub subscribe_mode: CollectorSubscriptionMode,
+}
+
+/// How to subscribe to subxt blocks
+#[derive(strum::Display, Debug, Clone, Copy, clap::ValueEnum, Default)]
+pub enum CollectorSubscriptionMode {
+	/// Subscribe to the best chain
+	Best,
+	/// Subscribe to finalized blocks
+	#[default]
+	Finalized,
 }
 
 /// This type is used to distinguish different keys in the storage
@@ -142,6 +154,7 @@ pub struct Collector {
 	broadcast_channels: Vec<BroadcastSender<CollectorUpdateEvent>>,
 	state: CollectorState,
 	executor: RequestExecutor,
+	subscribe_mode: CollectorSubscriptionMode,
 }
 
 impl Collector {
@@ -166,6 +179,7 @@ impl Collector {
 			state: Default::default(),
 			broadcast_channels: Default::default(),
 			executor,
+			subscribe_mode: opts.subscribe_mode,
 		}
 	}
 
@@ -214,20 +228,20 @@ impl Collector {
 
 	/// Collects chain events from new head including block events parsing
 	pub async fn collect_chain_events(&mut self, event: &SubxtEvent) -> color_eyre::Result<Vec<ChainEvent>> {
-		match event {
-			SubxtEvent::NewBestHead(block_hash) => {
-				let block_hash = *block_hash;
-				let mut chain_events = vec![ChainEvent::NewHead(block_hash)];
-				let block_events = self.executor.get_events(self.endpoint.as_str(), Some(block_hash)).await?;
+		if let Some(hash) = new_head_hash(event, self.subscribe_mode) {
+			let hash = *hash;
+			let mut chain_events = vec![ChainEvent::NewHead(hash)];
+			let block_events = self.executor.get_events(self.endpoint.as_str(), Some(hash)).await?;
 
-				if let Some(block_events) = block_events {
-					for block_event in block_events.iter() {
-						chain_events.push(decode_chain_event(block_hash, block_event.unwrap()).await?);
-					}
+			if let Some(block_events) = block_events {
+				for block_event in block_events.iter() {
+					chain_events.push(decode_chain_event(hash, block_event.unwrap()).await?);
 				}
+			}
 
-				Ok(chain_events)
-			},
+			Ok(chain_events)
+		} else {
+			Ok(vec![])
 		}
 	}
 
@@ -791,4 +805,12 @@ impl Collector {
 
 fn get_unix_time_unwrap() -> Duration {
 	SystemTime::now().duration_since(UNIX_EPOCH).unwrap()
+}
+
+pub fn new_head_hash(event: &SubxtEvent, subscribe_mode: CollectorSubscriptionMode) -> Option<&H256> {
+	match (event, subscribe_mode) {
+		(SubxtEvent::NewBestHead(hash), CollectorSubscriptionMode::Best) => Some(hash),
+		(SubxtEvent::NewFinalizedHead(hash), CollectorSubscriptionMode::Finalized) => Some(hash),
+		_ => None,
+	}
 }

--- a/src/core/subxt_subscription.rs
+++ b/src/core/subxt_subscription.rs
@@ -111,7 +111,7 @@ impl SubxtSubscription {
 							FollowEvent::Finalized(finalized) => {
 								for hash in finalized.finalized_block_hashes.iter() {
 									info!("[{}] Finalized block imported ({:?})", url, hash);
-									if let Err(e) = update_channel.send(SubxtEvent::NewBestHead(*hash)).await {
+									if let Err(e) = update_channel.send(SubxtEvent::NewFinalizedHead(*hash)).await {
 										return on_error(e);
 									}
 								}

--- a/src/core/subxt_subscription.rs
+++ b/src/core/subxt_subscription.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Parity Technologies (UK) Ltd.
+// Copyright 2023 Parity Technologies (UK) Ltd.
 // This file is part of polkadot-introspector.
 //
 // polkadot-introspector is free software: you can redistribute it and/or modify
@@ -17,41 +17,34 @@
 
 use super::{EventConsumerInit, EventStream, MAX_MSG_QUEUE_SIZE, RETRY_DELAY_MS};
 use async_trait::async_trait;
-use futures::{future, Stream, StreamExt};
+use futures::future;
 use log::{error, info};
-use std::{future::Future, pin::Pin};
-use subxt::{blocks::Block, Error, OnlineClient, PolkadotConfig};
+use subxt::{
+	rpc::{types::FollowEvent, Subscription},
+	utils::H256,
+	OnlineClient, PolkadotConfig,
+};
 use tokio::sync::{
 	broadcast::{Receiver as BroadcastReceiver, Sender as BroadcastSender},
-	mpsc::{channel, Sender},
+	mpsc::{channel, error::SendError, Sender},
 };
 
 #[derive(Debug)]
 pub enum SubxtEvent {
-	/// New relay chain head
-	NewHead(<PolkadotConfig as subxt::Config>::Hash),
+	/// New relay chain best head
+	NewBestHead(<PolkadotConfig as subxt::Config>::Hash),
+	/// New relay chain finalized head
+	NewFinalizedHead(<PolkadotConfig as subxt::Config>::Hash),
 }
 
-pub struct SubxtWrapper {
+pub struct SubxtSubscription {
 	urls: Vec<String>,
 	/// One sender per consumer per URL.
 	consumers: Vec<Vec<Sender<SubxtEvent>>>,
-	/// Mode of subscription
-	subscribe_mode: SubxtSubscriptionMode,
-}
-
-/// How to subscribe to subxt blocks
-#[derive(strum::Display, Debug, Clone, Copy, clap::ValueEnum, Default)]
-pub enum SubxtSubscriptionMode {
-	/// Subscribe to the best chain
-	Best,
-	/// Subscribe to finalized blocks
-	#[default]
-	Finalized,
 }
 
 #[async_trait]
-impl EventStream for SubxtWrapper {
+impl EventStream for SubxtSubscription {
 	type Event = SubxtEvent;
 
 	/// Create a new consumer of events. Returns consumer initialization data.
@@ -76,9 +69,10 @@ impl EventStream for SubxtWrapper {
 		tasks: Vec<tokio::task::JoinHandle<()>>,
 		shutdown_tx: BroadcastSender<()>,
 	) -> color_eyre::Result<()> {
-		let futures = self.consumers.into_iter().map(|update_channels| {
-			Self::run_per_consumer(update_channels, self.urls.clone(), self.subscribe_mode, shutdown_tx.clone())
-		});
+		let futures = self
+			.consumers
+			.into_iter()
+			.map(|update_channels| Self::run_per_consumer(update_channels, self.urls.clone(), shutdown_tx.clone()));
 
 		let mut flat_futures = futures.flatten().collect::<Vec<_>>();
 		flat_futures.extend(tasks);
@@ -88,51 +82,58 @@ impl EventStream for SubxtWrapper {
 	}
 }
 
-impl SubxtWrapper {
-	pub fn new(urls: Vec<String>, subscribe_mode: SubxtSubscriptionMode) -> SubxtWrapper {
-		SubxtWrapper { urls, consumers: Vec::new(), subscribe_mode }
+impl SubxtSubscription {
+	pub fn new(urls: Vec<String>) -> SubxtSubscription {
+		SubxtSubscription { urls, consumers: Vec::new() }
 	}
 
 	// Per consumer
-	async fn run_per_node(
-		update_channel: Sender<SubxtEvent>,
-		url: String,
-		subscribe_mode: SubxtSubscriptionMode,
-		shutdown_tx: BroadcastSender<()>,
-	) {
-		let mut shutdown_rx = shutdown_tx.subscribe();
-		loop {
-			tokio::select! {
-				client = OnlineClient::<PolkadotConfig>::from_url(url.clone()) => {
-					match client {
-						Ok(api) => {
-							info!("[{}] Connected", url);
-							match subscribe_mode {
-								SubxtSubscriptionMode::Best =>
-									process_subscription_or_stop(&update_channel, api.blocks().subscribe_best(), url.as_str(), shutdown_tx.subscribe())
-										.await,
-								SubxtSubscriptionMode::Finalized =>
-									process_subscription_or_stop(
-										&update_channel,
-										api.blocks().subscribe_finalized(),
-										url.as_str(),
-										shutdown_tx.subscribe()
-									)
-										.await,
-							};
-							break;
-						},
-						Err(err) => {
-							error!("[{}] Disconnected ({:?}) ", url, err);
-							// TODO (sometime): Add exponential backoff.
-							tokio::time::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS)).await;
-							info!("[{}] retrying connection ... ", url);
-						},
+	async fn run_per_node(update_channel: Sender<SubxtEvent>, url: String, shutdown_tx: BroadcastSender<()>) {
+		if let Some(api) = subxt_client(url.clone(), shutdown_tx.subscribe()).await {
+			let mut shutdown_rx = shutdown_tx.subscribe();
+			let (mut sub, sub_id) = subxt_chain_head_subscription(&api).await;
+
+			loop {
+				tokio::select! {
+					Some(Ok(event)) = sub.next() => {
+						match event {
+							// Drain the initialized event
+							FollowEvent::Initialized(init) => {
+								subxt_unpin_hash(&api, sub_id.clone(), init.finalized_block_hash).await;
+							},
+							FollowEvent::NewBlock(_) => continue,
+							FollowEvent::BestBlockChanged(best_block) => {
+								info!("[{}] Best block imported ({:?})", url, best_block.best_block_hash);
+								if let Err(e) = update_channel.send(SubxtEvent::NewBestHead(best_block.best_block_hash)).await {
+									return on_error(e);
+								}
+							},
+							FollowEvent::Finalized(finalized) => {
+								for hash in finalized.finalized_block_hashes.iter() {
+									info!("[{}] Finalized block imported ({:?})", url, hash);
+									if let Err(e) = update_channel.send(SubxtEvent::NewBestHead(*hash)).await {
+										return on_error(e);
+									}
+								}
+
+								for hash in finalized
+									.finalized_block_hashes
+									.iter()
+									.chain(finalized.pruned_block_hashes.iter())
+								{
+									subxt_unpin_hash(&api, sub_id.clone(), *hash).await;
+								}
+							},
+							FollowEvent::Stop => {
+								on_subscription_stop();
+								break;
+							},
+						}
+					},
+					_ = shutdown_rx.recv() => {
+						return on_ctrl_c();
 					}
-				}
-				_ = shutdown_rx.recv() => {
-					info!("received interrupt signal shutting down subscription");
-					return;
+
 				}
 			}
 		}
@@ -142,57 +143,62 @@ impl SubxtWrapper {
 	fn run_per_consumer(
 		update_channels: Vec<Sender<SubxtEvent>>,
 		urls: Vec<String>,
-		subscribe_mode: SubxtSubscriptionMode,
 		shutdown_tx: BroadcastSender<()>,
 	) -> Vec<tokio::task::JoinHandle<()>> {
 		update_channels
 			.into_iter()
 			.zip(urls.into_iter())
-			.map(|(update_channel, url)| {
-				tokio::spawn(Self::run_per_node(update_channel, url, subscribe_mode, shutdown_tx.clone()))
-			})
+			.map(|(update_channel, url)| tokio::spawn(Self::run_per_node(update_channel, url, shutdown_tx.clone())))
 			.collect()
 	}
 }
 
-// Subxt does not export this type but it is needed to specify future output
-type BlockStream<T> = Pin<Box<dyn Stream<Item = Result<T, Error>> + Send>>;
-
-// Process subscription to a specific block types (e.g. best, finalized) and returns `true`
-// if a caller's loop should be terminated.
-async fn process_subscription_or_stop<Sub, Client>(
-	update_channel: &Sender<SubxtEvent>,
-	subscription: Sub,
-	url: &str,
-	mut shutdown_rx: BroadcastReceiver<()>,
-) where
-	Sub: Future<Output = Result<BlockStream<Block<PolkadotConfig, Client>>, Error>> + Send + 'static,
-	Client: subxt::client::OnlineClientT<PolkadotConfig> + Send + Sync + 'static,
-{
+async fn subxt_client(url: String, mut shutdown_rx: BroadcastReceiver<()>) -> Option<OnlineClient<PolkadotConfig>> {
 	loop {
 		tokio::select! {
-			Ok(mut sub) = subscription => loop {
-				tokio::select! {
-					Some(block) = sub.next() => {
-						let block = block.unwrap();
-						let hash = block.hash();
-						info!("[{}] Block imported ({:?})", url, &hash);
-
-						if let Err(e) = update_channel.send(SubxtEvent::NewHead(hash)).await {
-							info!("Event consumer has terminated: {:?}, shutting down", e);
-							return;
-						}
+			client = OnlineClient::<PolkadotConfig>::from_url(url.clone()) => {
+				match client {
+					Ok(api) => {
+						info!("[{}] Connected", url);
+						return Some(api)
 					},
-					_ = shutdown_rx.recv() => {
-						info!("received interrupt signal shutting down subscription");
-						return;
-					}
+					Err(err) => {
+						error!("[{}] Disconnected ({:?}) ", url, err);
+						// TODO (sometime): Add exponential backoff.
+						tokio::time::sleep(std::time::Duration::from_millis(RETRY_DELAY_MS)).await;
+						info!("[{}] retrying connection ... ", url);
+					},
 				}
-			},
+			}
 			_ = shutdown_rx.recv() => {
-				info!("received interrupt signal shutting down subscription");
-				return;
+				on_ctrl_c();
+				return None;
 			}
 		}
 	}
+}
+
+async fn subxt_chain_head_subscription(
+	api: &OnlineClient<PolkadotConfig>,
+) -> (Subscription<FollowEvent<H256>>, String) {
+	let sub = api.rpc().chainhead_unstable_follow(false).await.unwrap();
+	let sub_id = sub.subscription_id().expect("A subscription ID must be provided").to_string();
+
+	(sub, sub_id)
+}
+
+async fn subxt_unpin_hash(api: &OnlineClient<PolkadotConfig>, sub_id: String, hash: H256) {
+	let _ = api.rpc().chainhead_unstable_unpin(sub_id.clone(), hash).await;
+}
+
+fn on_error(e: SendError<SubxtEvent>) {
+	info!("Event consumer has terminated: {:?}, shutting down", e);
+}
+
+fn on_subscription_stop() {
+	info!("Chain head subscription stopped");
+}
+
+fn on_ctrl_c() {
+	info!("received interrupt signal shutting down subscription");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Parity Technologies (UK) Ltd.
+// Copyright 2023 Parity Technologies (UK) Ltd.
 // This file is part of polkadot-introspector.
 //
 // polkadot-introspector is free software: you can redistribute it and/or modify
@@ -77,7 +77,7 @@ async fn main() -> color_eyre::Result<()> {
 
 	match opts.command {
 		Command::BlockTimeMonitor(opts) => {
-			let mut core = core::SubxtWrapper::new(opts.nodes.clone(), opts.subscribe_mode);
+			let mut core = core::SubxtSubscription::new(opts.nodes.clone());
 			let block_time_consumer_init = core.create_consumer();
 			let (shutdown_tx, _) = broadcast::channel(1);
 
@@ -112,7 +112,7 @@ async fn main() -> color_eyre::Result<()> {
 			kvdb::introspect_kvdb(opts).await?;
 		},
 		Command::ParachainCommander(opts) => {
-			let mut core = core::SubxtWrapper::new(vec![opts.node.clone()], opts.subscribe_mode);
+			let mut core = core::SubxtSubscription::new(vec![opts.node.clone()]);
 			let consumer_init = core.create_consumer();
 			let (shutdown_tx, _) = broadcast::channel(1);
 

--- a/src/pc/mod.rs
+++ b/src/pc/mod.rs
@@ -74,8 +74,6 @@ pub(crate) struct ParachainCommanderOptions {
 	#[clap(name = "blocks", long)]
 	block_count: Option<u32>,
 	/// Defines subscription mode
-	#[clap(short = 's', long = "subscribe-mode", default_value_t, value_enum)]
-	pub subscribe_mode: SubxtSubscriptionMode,
 	/// The number of last blocks with missing slots to display
 	#[clap(long = "last-skipped-slot-blocks", default_value = "10")]
 	pub last_skipped_slot_blocks: usize,

--- a/src/pc/mod.rs
+++ b/src/pc/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2022 Parity Technologies (UK) Ltd.
+// Copyright 2023 Parity Technologies (UK) Ltd.
 // This file is part of polkadot-introspector.
 //
 // polkadot-introspector is free software: you can redistribute it and/or modify
@@ -29,7 +29,7 @@
 
 use crate::core::{
 	collector::{Collector, CollectorOptions},
-	EventConsumerInit, RequestExecutor, SubxtEvent, SubxtSubscriptionMode,
+	EventConsumerInit, RequestExecutor, SubxtEvent,
 };
 use clap::Parser;
 use colored::Colorize;


### PR DESCRIPTION
Part of https://github.com/paritytech/polkadot-introspector/issues/197
Because we need to handle both types of blocks I changed subscription following the example https://github.com/paritytech/subxt/blob/lexnv/diff_best_last_finalized/examples/examples/subscribe_chain_head_events.rs#L58-L84

