### PR TITLE
Extract common types

### DIFF
--- a/essentials/src/api/mod.rs
+++ b/essentials/src/api/mod.rs
@@ -75,11 +75,8 @@ where
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::storage::StorageEntry;
-	use subxt::{
-		config::{substrate::BlakeTwo256, Hasher, Header},
-		utils::H256,
-	};
+	use crate::{storage::StorageEntry, types::H256};
+	use subxt::config::{substrate::BlakeTwo256, Hasher, Header};
 	#[cfg(feature = "polkadot")]
 	const RPC_NODE_URL: &str = "wss://rpc.polkadot.io:443";
 	#[cfg(feature = "rococo")]

--- a/essentials/src/api/subxt_wrapper.rs
+++ b/essentials/src/api/subxt_wrapper.rs
@@ -15,7 +15,6 @@ use std::collections::BTreeMap;
 // You should have received a copy of the GNU General Public License
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 //
-use crate::constants::{RETRY_COUNT, RETRY_DELAY_MS};
 pub use crate::metadata::polkadot::{
 	self, runtime_types as subxt_runtime_types,
 	runtime_types::{
@@ -25,11 +24,13 @@ pub use crate::metadata::polkadot::{
 		polkadot_runtime_parachains::{configuration::HostConfiguration, hrmp::HrmpChannel, scheduler::CoreAssignment},
 	},
 };
+use crate::{
+	constants::{RETRY_COUNT, RETRY_DELAY_MS},
+	types::{AccountId32, Timestamp, H256},
+};
 use codec::Decode;
 use log::error;
 use thiserror::Error;
-
-pub type BlockNumber = u32;
 
 #[cfg(feature = "rococo")]
 pub use subxt_runtime_types::rococo_runtime::RuntimeCall as SubxtCall;
@@ -38,10 +39,7 @@ pub use subxt_runtime_types::rococo_runtime::RuntimeCall as SubxtCall;
 pub use subxt_runtime_types::polkadot_runtime::RuntimeCall as SubxtCall;
 
 use std::{collections::hash_map::HashMap, fmt::Debug};
-use subxt::{
-	utils::{AccountId32, H256},
-	OnlineClient, PolkadotConfig,
-};
+use subxt::{OnlineClient, PolkadotConfig};
 
 /// Subxt based APIs for fetching via RPC and processing of extrinsics.
 pub enum RequestType {
@@ -140,7 +138,7 @@ pub type InherentData = polkadot_rt_primitives::v2::InherentData<
 /// Response types for APIs.
 pub enum Response {
 	/// A timestamp.
-	Timestamp(u64),
+	Timestamp(Timestamp),
 	/// A block header.
 	MaybeHead(Option<<PolkadotConfig as subxt::Config>::Header>),
 	/// A full block.
@@ -257,7 +255,7 @@ impl RequestExecutor {
 		&mut self,
 		url: &str,
 		maybe_hash: Option<<PolkadotConfig as subxt::Config>::Hash>,
-	) -> std::result::Result<u64, SubxtWrapperError> {
+	) -> std::result::Result<Timestamp, SubxtWrapperError> {
 		wrap_subxt_call!(self, GetBlockTimestamp, Timestamp, url, maybe_hash)
 	}
 

--- a/essentials/src/collector/candidate_record.rs
+++ b/essentials/src/collector/candidate_record.rs
@@ -16,7 +16,7 @@
 
 use crate::{
 	chain_events::SubxtDisputeResult,
-	metadata::polkadot::runtime_types::polkadot_primitives::v2 as polkadot_rt_primitives,
+	metadata::polkadot::runtime_types::polkadot_primitives::v2 as polkadot_rt_primitives, types::H256,
 };
 use codec::{Decode, Encode};
 use serde::{
@@ -25,7 +25,6 @@ use serde::{
 };
 use serde_bytes::Bytes;
 use std::{hash::Hash, time::Duration};
-use subxt::utils::H256;
 
 /// Tracks candidate inclusion as seen by a node(s)
 #[derive(Debug, Serialize, Deserialize, Encode, Decode, Clone)]

--- a/essentials/src/collector/mod.rs
+++ b/essentials/src/collector/mod.rs
@@ -24,6 +24,7 @@ use crate::{
 	},
 	storage::{RecordTime, RecordsStorageConfig, StorageEntry},
 	subxt_subscription::SubxtEvent,
+	types::{Timestamp, H256},
 };
 use candidate_record::{CandidateDisputed, CandidateInclusionRecord, CandidateRecord, DisputeResult};
 use clap::Parser;
@@ -44,7 +45,6 @@ use subxt::{
 		substrate::{BlakeTwo256, SubstrateHeader},
 		Hasher,
 	},
-	utils::H256,
 	PolkadotConfig,
 };
 use tokio::sync::broadcast::Sender as BroadcastSender;
@@ -442,7 +442,7 @@ impl Collector {
 		&mut self,
 		block_hash: H256,
 		header: SubstrateHeader<u32, BlakeTwo256>,
-		ts: u64,
+		ts: Timestamp,
 		block_number: u32,
 	) -> color_eyre::Result<()> {
 		info!(

--- a/essentials/src/collector/ws.rs
+++ b/essentials/src/collector/ws.rs
@@ -16,6 +16,7 @@
 use crate::{
 	chain_events::SubxtDisputeResult,
 	collector::{candidate_record::CandidateRecord, CollectorPrefixType, CollectorStorageApi},
+	types::{Timestamp, H256},
 };
 use futures::{SinkExt, StreamExt};
 use log::{debug, warn};
@@ -32,7 +33,6 @@ use std::{
 	str::FromStr,
 	time::{Duration, SystemTime, UNIX_EPOCH},
 };
-use subxt::utils::H256;
 use tokio::sync::broadcast::Receiver as BroadcastReceiver;
 use typed_builder::TypedBuilder;
 use warp::{
@@ -91,7 +91,7 @@ struct CandidatesQuery {
 	/// Filter candidates by parachain
 	parachain_id: Option<u32>,
 	/// Filter candidates by time
-	not_before: Option<u64>,
+	not_before: Option<Timestamp>,
 }
 
 /// Used to handle requests to get a specific candidate info
@@ -105,7 +105,7 @@ struct CandidateGetQuery {
 #[derive(Deserialize, Serialize)]
 struct HealthQuery {
 	/// Ping like field (optional)
-	ts: u64,
+	ts: Timestamp,
 }
 
 /// Common functions for a listener
@@ -201,7 +201,7 @@ pub struct HealthReply {
 	/// How many candidates have we processed
 	pub candidates_stored: usize,
 	/// Timestamp from a request or our local timestamp
-	pub ts: u64,
+	pub ts: Timestamp,
 }
 
 async fn health_handler(api: CollectorStorageApi, ping: Option<HealthQuery>) -> Result<impl Reply, Rejection> {

--- a/essentials/src/storage.rs
+++ b/essentials/src/storage.rs
@@ -33,7 +33,7 @@ use std::{
 	time::Duration,
 };
 
-pub type BlockNumber = u32;
+use crate::types::BlockNumber;
 
 /// A type to identify the record type
 #[derive(Clone, Debug, Copy, PartialEq, Eq)]

--- a/essentials/src/subxt_subscription.rs
+++ b/essentials/src/subxt_subscription.rs
@@ -18,6 +18,7 @@
 use crate::{
 	constants::{MAX_MSG_QUEUE_SIZE, RETRY_DELAY_MS},
 	consumer::{EventConsumerInit, EventStream},
+	types::H256,
 };
 use async_trait::async_trait;
 use futures::future;
@@ -25,7 +26,6 @@ use log::{error, info};
 use priority_channel::{channel, SendError, Sender};
 use subxt::{
 	rpc::{types::FollowEvent, Subscription},
-	utils::H256,
 	OnlineClient, PolkadotConfig,
 };
 use tokio::sync::broadcast::{Receiver as BroadcastReceiver, Sender as BroadcastSender};

--- a/essentials/src/telemetry_feed.rs
+++ b/essentials/src/telemetry_feed.rs
@@ -17,16 +17,14 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::value::RawValue;
-use subxt::utils::H256;
 
-type BlockHash = H256;
-type BlockNumber = u32;
-type Timestamp = u64;
+use crate::types::{BlockNumber, Timestamp, H256};
+
 pub type FeedNodeId = usize;
 
 #[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq)]
 pub struct Block {
-	pub hash: BlockHash,
+	pub hash: H256,
 	pub height: BlockNumber,
 }
 
@@ -34,7 +32,7 @@ pub struct Block {
 pub struct BlockDetails {
 	pub block: Block,
 	pub block_time: u64,
-	pub block_timestamp: u64,
+	pub block_timestamp: Timestamp,
 	pub propagation_time: Option<u64>,
 }
 
@@ -129,7 +127,7 @@ pub struct BestBlock {
 #[derive(Debug, PartialEq)]
 pub struct BestFinalized {
 	block_number: BlockNumber,
-	block_hash: BlockHash,
+	block_hash: H256,
 }
 
 #[derive(Debug, PartialEq)]
@@ -168,7 +166,7 @@ pub struct ImportedBlock {
 pub struct FinalizedBlock {
 	pub node_id: FeedNodeId,
 	block_number: BlockNumber,
-	block_hash: BlockHash,
+	block_hash: H256,
 }
 
 #[derive(Debug, PartialEq)]
@@ -191,23 +189,23 @@ pub struct TimeSync {
 #[derive(Debug, PartialEq)]
 pub struct AddedChain {
 	name: String,
-	genesis_hash: BlockHash,
+	genesis_hash: H256,
 	node_count: usize,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct RemovedChain {
-	genesis_hash: BlockHash,
+	genesis_hash: H256,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct SubscribedTo {
-	genesis_hash: BlockHash,
+	genesis_hash: H256,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct UnsubscribedFrom {
-	genesis_hash: BlockHash,
+	genesis_hash: H256,
 }
 
 #[derive(Debug, PartialEq)]
@@ -435,7 +433,7 @@ mod test {
 					timestamp: 1679657352067,
 					avg_block_time: Some(5998)
 				}),
-				TelemetryFeed::BestFinalized(BestFinalized { block_number: 14783934, block_hash: BlockHash::zero() })
+				TelemetryFeed::BestFinalized(BestFinalized { block_number: 14783934, block_hash: H256::zero() })
 			]
 		);
 	}
@@ -476,7 +474,7 @@ mod test {
 					chart_stamps: vec![1679673031643.2812, 1679673120180.5312, 1679673200282.875,]
 				},
 				block_details: BlockDetails {
-					block: Block { hash: BlockHash::zero(), height: 6321619 },
+					block: Block { hash: H256::zero(), height: 6321619 },
 					block_time: 0,
 					block_timestamp: 1679660148935,
 					propagation_time: None
@@ -514,7 +512,7 @@ mod test {
 				TelemetryFeed::ImportedBlock(ImportedBlock {
 					node_id: 297,
 					block_details: BlockDetails {
-						block: Block { hash: BlockHash::zero(), height: 11959 },
+						block: Block { hash: H256::zero(), height: 11959 },
 						block_time: 6073,
 						block_timestamp: 1679669286310,
 						propagation_time: Some(233)
@@ -523,7 +521,7 @@ mod test {
 				TelemetryFeed::FinalizedBlock(FinalizedBlock {
 					node_id: 92,
 					block_number: 12085,
-					block_hash: BlockHash::zero()
+					block_hash: H256::zero()
 				})
 			]
 		);
@@ -568,10 +566,10 @@ mod test {
 			vec![
 				TelemetryFeed::AddedChain(AddedChain {
 					name: "Tick 558".to_owned(),
-					genesis_hash: BlockHash::zero(),
+					genesis_hash: H256::zero(),
 					node_count: 2
 				}),
-				TelemetryFeed::RemovedChain(RemovedChain { genesis_hash: BlockHash::zero() })
+				TelemetryFeed::RemovedChain(RemovedChain { genesis_hash: H256::zero() })
 			]
 		);
 	}
@@ -582,8 +580,8 @@ mod test {
 		assert_eq!(
 			TelemetryFeed::from_bytes(msg.as_bytes()).unwrap(),
 			vec![
-				TelemetryFeed::SubscribedTo(SubscribedTo { genesis_hash: BlockHash::zero() }),
-				TelemetryFeed::UnsubscribedFrom(UnsubscribedFrom { genesis_hash: BlockHash::zero() })
+				TelemetryFeed::SubscribedTo(SubscribedTo { genesis_hash: H256::zero() }),
+				TelemetryFeed::UnsubscribedFrom(UnsubscribedFrom { genesis_hash: H256::zero() })
 			]
 		);
 	}

--- a/essentials/src/telemetry_subscription.rs
+++ b/essentials/src/telemetry_subscription.rs
@@ -15,13 +15,14 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+use crate::types::H256;
+
 use super::telemetry_feed::TelemetryFeed;
 use color_eyre::Report;
 use futures::SinkExt;
 use futures_util::StreamExt;
 use log::{debug, info, warn};
 use priority_channel::{SendError, Sender};
-use subxt::utils::H256;
 use tokio::{net::TcpStream, sync::broadcast::Sender as BroadcastSender};
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
 use url::Url;

--- a/essentials/src/types.rs
+++ b/essentials/src/types.rs
@@ -15,14 +15,9 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-pub mod api;
-pub mod chain_events;
-pub mod collector;
-pub mod constants;
-pub mod consumer;
-pub mod metadata;
-pub mod storage;
-pub mod subxt_subscription;
-pub mod telemetry_feed;
-pub mod telemetry_subscription;
-pub mod types;
+use subxt::utils;
+
+pub type BlockNumber = u32;
+pub type H256 = utils::H256;
+pub type AccountId32 = utils::AccountId32;
+pub type Timestamp = u64;

--- a/introspector/src/block_time/mod.rs
+++ b/introspector/src/block_time/mod.rs
@@ -27,6 +27,7 @@ use essentials::{
 	consumer::EventConsumerInit,
 	storage::RecordsStorageConfig,
 	subxt_subscription::SubxtEvent,
+	types::H256,
 };
 use log::{debug, info, warn};
 use priority_channel::Receiver;
@@ -40,7 +41,7 @@ use std::{
 		Arc, Mutex,
 	},
 };
-use subxt::{config::Header, utils::H256};
+use subxt::config::Header;
 
 #[derive(Clone, Debug, Parser)]
 #[clap(rename_all = "kebab-case")]

--- a/introspector/src/kvdb/decode.rs
+++ b/introspector/src/kvdb/decode.rs
@@ -26,9 +26,9 @@
 use crate::kvdb::IntrospectorKvdb;
 use color_eyre::{eyre::eyre, Result};
 use erased_serde::{serialize_trait_object, Serialize};
+use essentials::types::H256;
 use itertools::Itertools;
 use std::fmt::{Debug, Display, Formatter};
-use subxt::utils::H256;
 
 /// Decode result trait, used to display and format output of the decoder
 pub trait DecodeResult: Debug + Serialize + Display {}

--- a/introspector/src/pc/mod.rs
+++ b/introspector/src/pc/mod.rs
@@ -37,6 +37,7 @@ use essentials::{
 	collector::{Collector, CollectorOptions, CollectorStorageApi, CollectorUpdateEvent},
 	consumer::EventConsumerInit,
 	subxt_subscription::SubxtEvent,
+	types::H256,
 };
 use futures::{future, stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
@@ -44,7 +45,6 @@ use log::{error, info, warn};
 use priority_channel::{channel_with_capacities, Receiver, Sender};
 use prometheus::{Metrics, ParachainCommanderPrometheusOptions};
 use std::{collections::HashMap, default::Default, ops::DerefMut};
-use subxt::utils::H256;
 use tokio::sync::broadcast::Sender as BroadcastSender;
 use tracker::ParachainBlockTracker;
 

--- a/introspector/src/pc/progress.rs
+++ b/introspector/src/pc/progress.rs
@@ -19,12 +19,15 @@
 use super::tracker::DisputesTracker;
 use color_eyre::owo_colors::OwoColorize;
 use crossterm::style::Stylize;
-use essentials::{api::subxt_wrapper::SubxtHrmpChannel, chain_events::SubxtDisputeResult, storage::BlockNumber};
+use essentials::{
+	api::subxt_wrapper::SubxtHrmpChannel,
+	chain_events::SubxtDisputeResult,
+	types::{BlockNumber, Timestamp, H256},
+};
 use std::{
 	fmt::{self, Display, Formatter, Write},
 	time::Duration,
 };
-use subxt::utils::H256;
 
 #[derive(Clone, Default)]
 pub struct BitfieldsHealth {
@@ -66,9 +69,9 @@ pub struct ParachainProgressUpdate {
 	/// Parachain id.
 	pub para_id: u32,
 	/// Block timestamp.
-	pub timestamp: u64,
+	pub timestamp: Timestamp,
 	/// Previous timestamp
-	pub prev_timestamp: u64,
+	pub prev_timestamp: Timestamp,
 	/// Relay chain block number.
 	pub block_number: BlockNumber,
 	/// Relay chain block hash.
@@ -86,7 +89,7 @@ pub struct ParachainProgressUpdate {
 }
 
 /// Format the current block inherent timestamp.
-fn format_ts(duration: Duration, current_block_ts: u64) -> String {
+fn format_ts(duration: Duration, current_block_ts: Timestamp) -> String {
 	let dt = time::OffsetDateTime::from_unix_timestamp_nanos(current_block_ts as i128 * 1_000_000).unwrap();
 	format!(
 		"{} +{}",

--- a/introspector/src/pc/stats.rs
+++ b/introspector/src/pc/stats.rs
@@ -19,13 +19,13 @@
 use super::{progress::ParachainProgressUpdate, tracker::DisputesTracker};
 use color_eyre::owo_colors::OwoColorize;
 use crossterm::style::Stylize;
+use essentials::types::H256;
 use std::{
 	collections::VecDeque,
 	default::Default,
 	fmt::{self, Display, Formatter},
 	time::Duration,
 };
-use subxt::utils::H256;
 
 trait UsableNumber: PartialOrd + PartialEq + Into<f64> + Copy {
 	fn max() -> Self;

--- a/introspector/src/pc/tracker.rs
+++ b/introspector/src/pc/tracker.rs
@@ -23,19 +23,17 @@ use super::{
 use codec::{Decode, Encode};
 use essentials::{
 	api::subxt_wrapper::{
-		AvailabilityBitfield, BackedCandidate, BlockNumber, CoreAssignment, CoreOccupied, InherentData,
-		RequestExecutor, SubxtHrmpChannel, ValidatorIndex,
+		AvailabilityBitfield, BackedCandidate, CoreAssignment, CoreOccupied, InherentData, RequestExecutor,
+		SubxtHrmpChannel, ValidatorIndex,
 	},
 	chain_events::SubxtDisputeResult,
 	collector::{CollectorPrefixType, CollectorStorageApi, DisputeInfo},
 	metadata::polkadot::runtime_types::polkadot_primitives::v2::{DisputeStatement, DisputeStatementSet},
+	types::{AccountId32, BlockNumber, Timestamp, H256},
 };
 use log::{debug, error, info, warn};
 use std::{collections::BTreeMap, default::Default, fmt::Debug};
-use subxt::{
-	config::{substrate::BlakeTwo256, Hasher},
-	utils::{AccountId32, H256},
-};
+use subxt::config::{substrate::BlakeTwo256, Hasher};
 
 /// An abstract definition of a parachain block tracker.
 #[async_trait::async_trait]
@@ -146,11 +144,11 @@ pub struct SubxtTracker {
 	/// Disputes information if any disputes are there.
 	disputes: Vec<DisputesTracker>,
 	/// Current relay chain block timestamp.
-	current_relay_block_ts: Option<u64>,
+	current_relay_block_ts: Option<Timestamp>,
 	/// Last observed finality lag
 	finality_lag: Option<u32>,
 	/// Last relay chain block timestamp.
-	last_relay_block_ts: Option<u64>,
+	last_relay_block_ts: Option<Timestamp>,
 	/// Last included candidate in relay parent number
 	last_included_block: Option<BlockNumber>,
 	/// Messages queues status

--- a/introspector/src/telemetry/mod.rs
+++ b/introspector/src/telemetry/mod.rs
@@ -19,9 +19,9 @@ use essentials::{
 	constants::MAX_MSG_QUEUE_SIZE,
 	telemetry_feed::{AddedNode, FeedNodeId, TelemetryFeed},
 	telemetry_subscription::{TelemetryEvent, TelemetrySubscription},
+	types::H256,
 };
 use priority_channel::Receiver;
-use subxt::utils::H256;
 use tokio::sync::broadcast::Sender as BroadcastSender;
 
 macro_rules! print_for_node_id {


### PR DESCRIPTION
While moving the core to a package, I realized we reinvent some simple types across the bins. Not a big change, but it could help us to keep the code more accurate.