### PR TITLE
Panic if cannot get a host configuration

### DIFF
--- a/introspector/src/pc/mod.rs
+++ b/introspector/src/pc/mod.rs
@@ -41,7 +41,7 @@ use essentials::{
 };
 use futures::{future, stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
-use log::{error, info};
+use log::{error, info, warn};
 use priority_channel::{channel_with_capacities, Receiver, Sender};
 use prometheus::{Metrics, ParachainCommanderPrometheusOptions};
 use std::{collections::HashMap, default::Default, ops::DerefMut};
@@ -122,7 +122,8 @@ impl ParachainCommander {
 		let mut collector = Collector::new(self.opts.node.as_str(), self.opts.collector_opts.clone());
 		collector.spawn(shutdown_tx).await?;
 		if let Err(e) = print_host_configuration(self.opts.node.as_str(), &mut collector.executor()).await {
-			panic!("Cannot get host configuration: {}", e);
+			warn!("Cannot get host configuration");
+			return Err(e)
 		}
 
 		println!(

--- a/introspector/src/pc/mod.rs
+++ b/introspector/src/pc/mod.rs
@@ -41,7 +41,7 @@ use essentials::{
 };
 use futures::{future, stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
-use log::{error, info, warn};
+use log::{error, info};
 use priority_channel::{channel_with_capacities, Receiver, Sender};
 use prometheus::{Metrics, ParachainCommanderPrometheusOptions};
 use std::{collections::HashMap, default::Default, ops::DerefMut};
@@ -121,13 +121,9 @@ impl ParachainCommander {
 
 		let mut collector = Collector::new(self.opts.node.as_str(), self.opts.collector_opts.clone());
 		collector.spawn(shutdown_tx).await?;
-		print_host_configuration(self.opts.node.as_str(), &mut collector.executor())
-			.await
-			.map_err(|e| {
-				warn!("Cannot get host configuration: {}", e);
-				e
-			})
-			.unwrap_or_default();
+		if let Err(e) = print_host_configuration(self.opts.node.as_str(), &mut collector.executor()).await {
+			panic!("Cannot get host configuration: {}", e);
+		}
 
 		println!(
 			"{} will trace parachain(s) {} on {}\n{}",


### PR DESCRIPTION
Getting a host configuration is a first request via web socket. And if the tool can't establish the connection, it tries a few times, then warns and goes further trying to request chain updates in an infinite loop. I think it's better to panic right away after reaching the retry_count on getting a host details because it means that probably something wrong with the host. 