### PR TITLE
Choose chain from the list in telemetry feed

### DIFF
--- a/essentials/src/telemetry_feed.rs
+++ b/essentials/src/telemetry_feed.rs
@@ -186,11 +186,22 @@ pub struct TimeSync {
 	time: Timestamp,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct AddedChain {
-	name: String,
-	genesis_hash: H256,
-	node_count: usize,
+	pub name: String,
+	pub genesis_hash: H256,
+	pub node_count: usize,
+}
+
+impl std::fmt::Display for AddedChain {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		let node_count = match self.node_count {
+			0 => "no nodes".to_owned(),
+			1 => "1 node".to_owned(),
+			count => format!("{} nodes", count),
+		};
+		write!(f, "{}, {}, {}", self.name, self.genesis_hash, node_count)
+	}
 }
 
 #[derive(Debug, PartialEq)]

--- a/essentials/src/telemetry_feed.rs
+++ b/essentials/src/telemetry_feed.rs
@@ -195,12 +195,7 @@ pub struct AddedChain {
 
 impl std::fmt::Display for AddedChain {
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-		let node_count = match self.node_count {
-			0 => "no nodes".to_owned(),
-			1 => "1 node".to_owned(),
-			count => format!("{} nodes", count),
-		};
-		write!(f, "{}, {}, {}", self.name, self.genesis_hash, node_count)
+		write!(f, "{}, {}, {} node(s)", self.name, self.genesis_hash, self.node_count)
 	}
 }
 

--- a/essentials/src/telemetry_subscription.rs
+++ b/essentials/src/telemetry_subscription.rs
@@ -15,17 +15,50 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-use crate::types::H256;
-
 use super::telemetry_feed::TelemetryFeed;
+use crate::{telemetry_feed::AddedChain, types::H256};
 use color_eyre::Report;
-use futures::SinkExt;
+use futures::{stream::Next, SinkExt};
 use futures_util::StreamExt;
+use itertools::Itertools;
 use log::{debug, info, warn};
 use priority_channel::{SendError, Sender};
+use std::{
+	cmp::Reverse,
+	collections::HashMap,
+	io::{stdin, BufRead},
+};
 use tokio::{net::TcpStream, sync::broadcast::Sender as BroadcastSender};
 use tokio_tungstenite::{connect_async, tungstenite::Message, MaybeTlsStream, WebSocketStream};
-use url::Url;
+
+struct TelemetryStream {
+	ws_stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
+}
+
+impl TelemetryStream {
+	async fn connect(url: &str) -> Self {
+		println!("Connecting to the telemetry server on {}", url);
+		let (ws_stream, _) = connect_async(url).await.expect("Failed to connect");
+		Self { ws_stream }
+	}
+
+	async fn subscribe_to(&mut self, chain: &H256) -> color_eyre::Result<()> {
+		match self.ws_stream.send(Message::Text(format!("subscribe:{:?}", chain))).await {
+			Ok(_) => {
+				info!("Subscribed to chain with hash {}", chain);
+				Ok(())
+			},
+			Err(e) => {
+				info!("Cannot subscribe to chain with hash {}: {:?}", chain, e);
+				Err(e.into())
+			},
+		}
+	}
+
+	fn next(&mut self) -> Next<'_, WebSocketStream<MaybeTlsStream<TcpStream>>> {
+		self.ws_stream.next()
+	}
+}
 
 #[derive(Debug)]
 pub enum TelemetryEvent {
@@ -47,15 +80,16 @@ impl TelemetrySubscription {
 	async fn run_per_consumer(
 		mut update_channel: Sender<TelemetryEvent>,
 		url: String,
-		chain_hash: H256,
 		shutdown_tx: BroadcastSender<()>,
 	) {
 		let mut shutdown_rx = shutdown_tx.subscribe();
-		let mut ws_stream = telemetry_stream(&url, chain_hash).await;
+		let mut stream = TelemetryStream::connect(&url).await;
+		let mut current_chain: H256 = H256::zero();
+		let mut chains: HashMap<H256, AddedChain> = Default::default();
 
 		loop {
 			tokio::select! {
-				Some(Ok(msg)) = ws_stream.next() => {
+				Some(Ok(msg)) = stream.next() => {
 					let bytes = match msg {
 						Message::Text(text) => text.into_bytes(),
 						Message::Binary(bytes) => bytes,
@@ -68,9 +102,24 @@ impl TelemetrySubscription {
 					}
 
 					for message in feed.unwrap() {
+						if let TelemetryFeed::AddedChain(chain) = &message {
+							chains.insert(chain.genesis_hash, chain.clone());
+						}
 						debug!("[telemetry] {:?}", message);
 						if let Err(e) = update_channel.send(TelemetryEvent::NewMessage(message)).await {
 							return on_consumer_error(e);
+						}
+					}
+
+					if H256::is_zero(&current_chain) {
+						match choose_chain(&chains).await {
+							Ok(hash) => {
+								current_chain = hash;
+								let _ = stream.subscribe_to(&current_chain).await;
+							},
+							Err(_) => {
+								return on_no_chains();
+							}
 						}
 					}
 				},
@@ -84,27 +133,62 @@ impl TelemetrySubscription {
 	pub async fn run(
 		self,
 		url: String,
-		chain_hash: H256,
 		shutdown_tx: BroadcastSender<()>,
 	) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>> {
 		Ok(self
 			.consumers
 			.into_iter()
 			.map(|update_channel| {
-				tokio::spawn(Self::run_per_consumer(update_channel, url.clone(), chain_hash, shutdown_tx.clone()))
+				tokio::spawn(Self::run_per_consumer(update_channel, url.clone(), shutdown_tx.clone()))
 			})
 			.collect::<Vec<_>>())
 	}
 }
 
-async fn telemetry_stream(url: &str, chain_hash: H256) -> WebSocketStream<MaybeTlsStream<TcpStream>> {
-	let url = Url::parse(url).unwrap();
-	let (mut ws_stream, _) = connect_async(url).await.expect("Failed to connect");
-	if let Err(e) = ws_stream.send(Message::Text(format!("subscribe:{:?}", chain_hash))).await {
-		info!("Cannot subscribe to chain with hash {}: {:?}", chain_hash, e);
+async fn choose_chain(chains: &HashMap<H256, AddedChain>) -> color_eyre::Result<H256, ()> {
+	let list: Vec<AddedChain> = chains
+		.iter()
+		.map(|(_, v)| v.clone())
+		.sorted_by_key(|c| Reverse(c.node_count))
+		.collect();
+	let list_size = list.len();
+
+	match list_size {
+		0 => {
+			println!("No chains found...");
+			return Err(())
+		},
+		1 => {
+			println!("Found 1 chain.\n{}", list[0]);
+			return Ok(list[0].genesis_hash.clone())
+		},
+		_ => {
+			println!("Found {} chains.\nPlease input the number of chain you want to follow", list_size);
+			for (i, chain) in list.iter().enumerate() {
+				println!("{}. {}", i, chain);
+			}
+		},
 	}
 
-	ws_stream
+	let chain_index: usize;
+	print!("> ");
+	loop {
+		let mut buf = String::new();
+		stdin().lock().read_line(&mut buf).expect("Failed to read line");
+
+		match buf.trim().parse::<usize>() {
+			Ok(num) => match num {
+				1.. if num < list_size => {
+					chain_index = num - 1;
+					break
+				},
+				_ => continue,
+			},
+			Err(_) => continue,
+		};
+	}
+
+	Ok(list[chain_index].genesis_hash.clone())
 }
 
 fn on_consumer_error(e: SendError) {
@@ -113,6 +197,10 @@ fn on_consumer_error(e: SendError) {
 
 fn on_error(e: Report) {
 	warn!("Cannot parse telemetry feed: {:?}", e);
+}
+
+fn on_no_chains() {
+	warn!("No chains found, terminating...");
 }
 
 fn on_ctrl_c() {

--- a/essentials/src/telemetry_subscription.rs
+++ b/essentials/src/telemetry_subscription.rs
@@ -162,7 +162,7 @@ async fn choose_chain(chains: &HashMap<H256, AddedChain>) -> color_eyre::Result<
 		},
 		1 => {
 			println!("Found 1 chain.\n{}", list[0]);
-			return Ok(list[0].genesis_hash.clone())
+			return Ok(list[0].genesis_hash)
 		},
 		size => {
 			println!("Found {} chains.\n", size);
@@ -183,12 +183,12 @@ async fn choose_chain(chains: &HashMap<H256, AddedChain>) -> color_eyre::Result<
 		);
 		stdin().lock().read_line(&mut buf).expect("Failed to read line");
 
-		if buf == "\n".to_owned() {
+		if buf == *"\n" {
 			cursor = if cursor + CHAINS_CHUNK_SIZE < list_size { cursor + CHAINS_CHUNK_SIZE } else { 0 };
 			continue
 		}
 
-		if buf.trim().to_lowercase() == "q".to_owned() {
+		if buf.trim().to_lowercase() == *"q" {
 			return Err(())
 		}
 
@@ -210,7 +210,7 @@ async fn choose_chain(chains: &HashMap<H256, AddedChain>) -> color_eyre::Result<
 	let selected = &list[chain_index];
 	println!("\nSelected {}\n", selected);
 
-	Ok(selected.genesis_hash.clone())
+	Ok(selected.genesis_hash)
 }
 
 fn on_consumer_error(e: SendError) {


### PR DESCRIPTION
Now we have to pass a genesis hash to subscribe to a particular chain in the telemetry feed what could be annoying. So I changed it to choose the chain from a list on start.