### PR TITLE
Bump v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,7 +1703,7 @@ checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "polkadot-block-time"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "color-eyre",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-introspector"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1756,7 +1756,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-introspector-essentials"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-introspector-priority-channel"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-channel",
  "derive_more",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-kvdb"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "clap",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "polkadot-metadata-checker"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "color-eyre",

--- a/block-time/Cargo.toml
+++ b/block-time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polkadot-block-time"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/essentials/Cargo.toml
+++ b/essentials/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polkadot-introspector-essentials"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/introspector/Cargo.toml
+++ b/introspector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polkadot-introspector"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/kvdb/Cargo.toml
+++ b/kvdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polkadot-kvdb"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/metadata-checker/Cargo.toml
+++ b/metadata-checker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polkadot-metadata-checker"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/priority-channel/Cargo.toml
+++ b/priority-channel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polkadot-introspector-priority-channel"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 description = "Channels with message prioritization"


### PR DESCRIPTION
After we switched to deployment on a tag and split some packages, we need a new deployment/version to release. I jumped to 0.2.0 because the changes look significant comparing to the previous version.

We still have block-time in both forms: as a package and inside the introspector. I need it to not break the deployment. After switching to deploying of block-time with new exe, I'm going to remove the old one and release 0.2.1. 