### PR TITLE
Move deps to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "block-time",
     "essentials",
@@ -17,3 +18,44 @@ edition = "2021"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/paritytech/polkadot-introspector"
+
+[workspace.dependencies]
+async-channel = "1.8.0"
+async-trait = "0.1.66"
+bincode = "1.3.3"
+clap = { version = "4.3.5", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive", "full", "bit-vec"] }
+color-eyre = "0.6.2"
+colored = "2.0.0"
+crossterm = "0.26.1"
+env_logger = "0.10.0"
+erased-serde = "0.3.25"
+futures = "0.3.28"
+futures-util = "0.3.27"
+hex = "0.4.3"
+itertools = "0.10.5"
+log = "0.4.19"
+parity-db = "0.4.8"
+prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "master" }
+rand = "0.8.5"
+rasciigraph = "0.2.0"
+reqwest = { version = "0.11.18" }
+rocksdb = "0.21.0"
+serde = "1.0.164"
+serde_bytes = "0.11.9"
+serde_derive = "1.0.138"
+serde_json = "1.0.97"
+serde_urlencoded = "0.7.1"
+snap = "1.1.0"
+strum = { version = "0.25.0", features = ["derive"] }
+subxt = { default-features = false, features = ["jsonrpsee-ws"], version = "0.29.0" }
+thiserror = "1.0.39"
+time = { version = "0.3.22", features = ["formatting"] }
+tokio = { version = "1.28.2", features = ["macros", "rt", "rt-multi-thread", "signal"] }
+tokio-tungstenite = { version = "0.19.0", features = ["native-tls"] }
+typed-builder = "0.14.0"
+url = "2.4.0"
+warp = { version = "0.3.5", features = ["tls"] }
+
+polkadot-introspector-essentials = { path = "essentials" }
+polkadot-introspector-priority-channel = { path = "priority-channel" }

--- a/block-time/Cargo.toml
+++ b/block-time/Cargo.toml
@@ -8,15 +8,15 @@ repository.workspace = true
 publish = true
 
 [dependencies]
-clap = { version = "4.3.5", features = ["derive"] }
-color-eyre = "0.6.2"
-colored = "2.0.0"
-crossterm = "0.26.1"
-env_logger = "0.10.0"
-log = "0.4.19"
-polkadot-introspector-essentials = { path = "../essentials" }
-polkadot-introspector-priority-channel = { path = "../priority-channel" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "master" }
-rasciigraph = "0.2.0"
-subxt = { default-features = false, features = ["jsonrpsee-ws"], version = "0.29.0" }
-tokio = { version = "1.28.2", features = ["macros", "rt-multi-thread", "signal"] }
+clap = { workspace = true }
+color-eyre = { workspace = true }
+colored = { workspace = true }
+crossterm = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
+polkadot-introspector-essentials = { workspace = true }
+polkadot-introspector-priority-channel = { workspace = true }
+prometheus-endpoint = { workspace = true }
+rasciigraph = { workspace = true }
+subxt = { workspace = true }
+tokio = { workspace = true }

--- a/essentials/Cargo.toml
+++ b/essentials/Cargo.toml
@@ -10,7 +10,7 @@ publish = true
 [dependencies]
 async-trait = { workspace = true }
 clap = { workspace = true }
-codec = { workspace = true }
+codec = { package = "parity-scale-codec", workspace = true }
 color-eyre = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }

--- a/essentials/Cargo.toml
+++ b/essentials/Cargo.toml
@@ -8,31 +8,31 @@ repository.workspace = true
 publish = true
 
 [dependencies]
-async-trait = "0.1.66"
-clap = { version = "4.3.5", features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive", "full", "bit-vec"] }
-color-eyre = "0.6.2"
-env_logger = "0.10.0"
-futures = "0.3.27"
-futures-util = "0.3.27"
-hex = "0.4.3"
-itertools = "0.10.5"
-log = "0.4.19"
-polkadot-introspector-priority-channel = { path = "../priority-channel" }
-rand = "0.8.5"
-serde = "1.0.164"
-serde_bytes = "0.11.9"
-serde_derive = "1.0.138"
-serde_json = "1.0.97"
-serde_urlencoded = "0.7.1"
-strum = { version = "0.25.0", features = ["derive"] }
-subxt = { default-features = false, features = ["jsonrpsee-ws"], version = "0.29.0" }
-thiserror = "1.0.39"
-tokio = { version = "1.28.2", features = ["macros", "rt-multi-thread", "signal"] }
-tokio-tungstenite = { version = "0.19.0", features = ["native-tls"] }
-typed-builder = "0.14.0"
-url = "2.4.0"
-warp = { version = "0.3.5", features = ["tls"] }
+async-trait = { workspace = true }
+clap = { workspace = true }
+codec = { workspace = true }
+color-eyre = { workspace = true }
+env_logger = { workspace = true }
+futures = { workspace = true }
+futures-util = { workspace = true }
+hex = { workspace = true }
+itertools = { workspace = true }
+log = { workspace = true }
+polkadot-introspector-priority-channel = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_bytes = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+serde_urlencoded = { workspace = true }
+strum = { workspace = true }
+subxt = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tokio-tungstenite = { workspace = true }
+typed-builder = { workspace = true }
+url = { workspace = true }
+warp = { workspace = true }
 
 [features]
 rococo = []

--- a/jaeger/Cargo.toml
+++ b/jaeger/Cargo.toml
@@ -8,17 +8,17 @@ repository.workspace = true
 publish = true
 
 [dependencies]
-clap = { version = "4.3.5", features = ["derive"] }
-color-eyre = "0.6.2"
-env_logger = "0.10.0"
-futures = "0.3.28"
-log = "0.4.19"
-polkadot-introspector-essentials = { path = "../essentials" }
-reqwest = { version = "0.11.18" }
-serde = "1.0.164"
-serde_bytes = "0.11.9"
-serde_derive = "1.0.138"
-serde_json = "1.0.97"
-serde_urlencoded = "0.7.1"
-tokio = { version = "1.28.2", features = ["macros", "rt-multi-thread", "signal"] }
-typed-builder = "0.14.0"
+clap = { workspace = true }
+color-eyre = { workspace = true }
+env_logger = { workspace = true }
+futures = { workspace = true }
+log = { workspace = true }
+polkadot-introspector-essentials = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_bytes = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+serde_urlencoded = { workspace = true }
+tokio = { workspace = true }
+typed-builder = { workspace = true }

--- a/kvdb/Cargo.toml
+++ b/kvdb/Cargo.toml
@@ -8,25 +8,25 @@ repository.workspace = true
 publish = true
 
 [dependencies]
-bincode = "1.3.3"
-clap = { version = "4.3.5", features = ["derive"] }
-color-eyre = "0.6.2"
-env_logger = "0.10.0"
-erased-serde = "0.3.25"
-futures = "0.3.28"
-hex = "0.4.3"
-itertools = "0.10.5"
-log = "0.4.19"
-parity-db = "0.4.8"
-polkadot-introspector-essentials = { path = "../essentials" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "master" }
-rand = "0.8.5"
-rocksdb = "0.21.0"
-serde = "1.0.164"
-serde_bytes = "0.11.9"
-serde_derive = "1.0.138"
-serde_json = "1.0.97"
-serde_urlencoded = "0.7.1"
-snap = "1.1.0"
-strum = { version = "0.25.0", features = ["derive"] }
-tokio = { version = "1.28.2", features = ["macros", "rt-multi-thread", "signal"] }
+bincode = { workspace = true }
+clap = { workspace = true }
+color-eyre = { workspace = true }
+env_logger = { workspace = true }
+erased-serde = { workspace = true }
+futures = { workspace = true }
+hex = { workspace = true }
+itertools = { workspace = true }
+log = { workspace = true }
+parity-db = { workspace = true }
+polkadot-introspector-essentials = { workspace = true }
+prometheus-endpoint = { workspace = true }
+rand = { workspace = true }
+rocksdb = { workspace = true }
+serde = { workspace = true }
+serde_bytes = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+serde_urlencoded = { workspace = true }
+snap = { workspace = true }
+strum = { workspace = true }
+tokio = { workspace = true }

--- a/metadata-checker/Cargo.toml
+++ b/metadata-checker/Cargo.toml
@@ -8,11 +8,11 @@ repository.workspace = true
 publish = true
 
 [dependencies]
-clap = { version = "4.3.5", features = ["derive"] }
-color-eyre = "0.6.2"
-crossterm = "0.26.1"
-env_logger = "0.10.0"
-log = "0.4.19"
-polkadot-introspector-essentials = { path = "../essentials" }
-subxt = { default-features = false, features = ["jsonrpsee-ws"], version = "0.29.0" }
-tokio = { version = "1.28.2", features = ["macros", "rt-multi-thread", "signal"] }
+clap = { workspace = true }
+color-eyre = { workspace = true }
+crossterm = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
+polkadot-introspector-essentials = { workspace = true }
+subxt = { workspace = true }
+tokio = { workspace = true }

--- a/parachain-tracer/Cargo.toml
+++ b/parachain-tracer/Cargo.toml
@@ -8,29 +8,29 @@ repository.workspace = true
 publish = true
 
 [dependencies]
-async-trait = "0.1.66"
-clap = { version = "4.3.5", features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.2.1", default-features = false, features = ["derive", "full", "bit-vec"] }
-color-eyre = "0.6.2"
-colored = "2.0.0"
-crossterm = "0.26.1"
-env_logger = "0.10.0"
-futures = "0.3.28"
-itertools = "0.10.5"
-log = "0.4.19"
-polkadot-introspector-essentials = { path = "../essentials" }
-polkadot-introspector-priority-channel = { path = "../priority-channel" }
-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/substrate", branch = "master" }
-rand = "0.8.5"
-serde = "1.0.164"
-serde_bytes = "0.11.9"
-serde_derive = "1.0.138"
-serde_json = "1.0.97"
-serde_urlencoded = "0.7.1"
-strum = { version = "0.25.0", features = ["derive"] }
-subxt = { default-features = false, features = ["jsonrpsee-ws"], version = "0.29.0" }
-thiserror = "1.0.39"
-time = { version = "0.3.22", features = ["formatting"] }
-tokio = { version = "1.28.2", features = ["macros", "rt-multi-thread", "signal"] }
-typed-builder = "0.14.0"
-warp = { version = "0.3.5", features = ["tls"] }
+async-trait = { workspace = true }
+clap = { workspace = true }
+codec = { workspace = true }
+color-eyre = { workspace = true }
+colored = { workspace = true }
+crossterm = { workspace = true }
+env_logger = { workspace = true }
+futures = { workspace = true }
+itertools = { workspace = true }
+log = { workspace = true }
+polkadot-introspector-essentials = { workspace = true }
+polkadot-introspector-priority-channel = { workspace = true }
+prometheus-endpoint = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true }
+serde_bytes = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+serde_urlencoded = { workspace = true }
+strum = { workspace = true }
+subxt = { workspace = true }
+thiserror = { workspace = true }
+time = { workspace = true }
+tokio = { workspace = true }
+typed-builder = { workspace = true }
+warp = { workspace = true }

--- a/parachain-tracer/Cargo.toml
+++ b/parachain-tracer/Cargo.toml
@@ -10,7 +10,7 @@ publish = true
 [dependencies]
 async-trait = { workspace = true }
 clap = { workspace = true }
-codec = { workspace = true }
+codec = { package = "parity-scale-codec", workspace = true }
 color-eyre = { workspace = true }
 colored = { workspace = true }
 crossterm = { workspace = true }

--- a/priority-channel/Cargo.toml
+++ b/priority-channel/Cargo.toml
@@ -9,10 +9,10 @@ repository.workspace = true
 publish = true
 
 [dependencies]
-async-channel = "1.8.0"
-futures = "0.3.28"
-rand = "0.8.5"
-thiserror = "1.0.31"
+async-channel = { workspace = true }
+futures = { workspace = true }
+rand = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1.28.2", features = ["macros", "rt"] }
+tokio = { workspace = true }

--- a/whois/Cargo.toml
+++ b/whois/Cargo.toml
@@ -8,12 +8,12 @@ repository.workspace = true
 publish = true
 
 [dependencies]
-clap = { version = "4.3.5", features = ["derive"] }
-color-eyre = "0.6.2"
-env_logger = "0.10.0"
-futures = "0.3.28"
-log = "0.4.19"
-polkadot-introspector-essentials = { path = "../essentials" }
-polkadot-introspector-priority-channel = { path = "../priority-channel" }
-thiserror = "1.0.39"
-tokio = { version = "1.28.2", features = ["macros", "rt-multi-thread", "signal"] }
+clap = { workspace = true }
+color-eyre = { workspace = true }
+env_logger = { workspace = true }
+futures = { workspace = true }
+log = { workspace = true }
+polkadot-introspector-essentials = { workspace = true }
+polkadot-introspector-priority-channel = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-introspector/issues/384

Note: package = "parity-scale-codec" is needed in the crate, because the macro uses https://github.com/bkchr/proc-macro-crate, which relies on finding that key in the local TOML (see https://github.com/bkchr/proc-macro-crate/issues/34).