### PR TITLE
[WIP] Allow using env vars for rpc node url in tests

### DIFF
--- a/essentials/src/api/mod.rs
+++ b/essentials/src/api/mod.rs
@@ -78,12 +78,17 @@ mod tests {
 	use super::*;
 	use crate::{storage::StorageEntry, types::H256};
 	use subxt::config::{substrate::BlakeTwo256, Hasher, Header};
-	#[cfg(feature = "rococo")]
-	const RPC_NODE_URL: &str = "wss://rococo-rpc.polkadot.io:443";
-	#[cfg(feature = "kusama")]
-	const RPC_NODE_URL: &str = "wss://kusama-rpc.polkadot.io:443";
-	#[cfg(feature = "polkadot")]
-	const RPC_NODE_URL: &str = "wss://rpc.polkadot.io:443";
+
+	fn rpc_node_url() -> String {
+		#[cfg(feature = "rococo")]
+		let url: String = "wss://rococo-rpc.polkadot.io:443".to_string();
+		#[cfg(feature = "kusama")]
+		let url: String = "wss://kusama-rpc.polkadot.io:443".to_string();
+		#[cfg(feature = "polkadot")]
+		let url: String = "wss://rpc.polkadot.io:443".to_string();
+
+		std::env::var("RPC_NODE_URL").unwrap_or(url)
+	}
 
 	#[tokio::test]
 	async fn basic_storage_test() {
@@ -100,23 +105,25 @@ mod tests {
 
 	#[tokio::test]
 	async fn basic_subxt_test() {
+		let node_url = rpc_node_url();
 		let api =
 			ApiService::<H256>::new_with_storage(RecordsStorageConfig { max_blocks: 10 }, RetryOptions::default());
 		let mut subxt = api.subxt();
 
-		let head = subxt.get_block_head(RPC_NODE_URL, None).await.unwrap().unwrap();
-		let timestamp = subxt.get_block_timestamp(RPC_NODE_URL, head.hash()).await.unwrap();
-		let _block = subxt.get_block(RPC_NODE_URL, Some(head.hash())).await.unwrap().unwrap();
+		let head = subxt.get_block_head(&node_url, None).await.unwrap().unwrap();
+		let timestamp = subxt.get_block_timestamp(&node_url, head.hash()).await.unwrap();
+		let _block = subxt.get_block(&node_url, Some(head.hash())).await.unwrap().unwrap();
 		assert!(timestamp > 0);
 	}
 
 	#[tokio::test]
 	async fn extract_parainherent_data() {
+		let node_url = rpc_node_url();
 		let api = ApiService::<H256>::new_with_storage(RecordsStorageConfig { max_blocks: 1 }, RetryOptions::default());
 		let mut subxt = api.subxt();
 
 		subxt
-			.extract_parainherent_data(RPC_NODE_URL, None)
+			.extract_parainherent_data(&node_url, None)
 			.await
 			.unwrap()
 			.expect("Inherent data must be present");
@@ -124,31 +131,34 @@ mod tests {
 
 	#[tokio::test]
 	async fn get_scheduled_paras() {
+		let node_url = rpc_node_url();
 		let api = ApiService::<H256>::new_with_storage(RecordsStorageConfig { max_blocks: 1 }, RetryOptions::default());
 		let mut subxt = api.subxt();
 
-		let head = subxt.get_block_head(RPC_NODE_URL, None).await.unwrap().unwrap();
+		let head = subxt.get_block_head(&node_url, None).await.unwrap().unwrap();
 
-		assert!(!subxt.get_scheduled_paras(RPC_NODE_URL, head.hash()).await.unwrap().is_empty())
+		assert!(!subxt.get_scheduled_paras(&node_url, head.hash()).await.unwrap().is_empty())
 	}
 
 	#[tokio::test]
 	async fn get_occupied_cores() {
+		let node_url = rpc_node_url();
 		let api = ApiService::<H256>::new_with_storage(RecordsStorageConfig { max_blocks: 1 }, RetryOptions::default());
 		let mut subxt = api.subxt();
 
-		let head = subxt.get_block_head(RPC_NODE_URL, None).await.unwrap().unwrap();
+		let head = subxt.get_block_head(&node_url, None).await.unwrap().unwrap();
 
-		assert!(!subxt.get_occupied_cores(RPC_NODE_URL, head.hash()).await.unwrap().is_empty())
+		assert!(!subxt.get_occupied_cores(&node_url, head.hash()).await.unwrap().is_empty())
 	}
 
 	#[tokio::test]
 	async fn get_backing_groups() {
+		let node_url = rpc_node_url();
 		let api = ApiService::<H256>::new_with_storage(RecordsStorageConfig { max_blocks: 1 }, RetryOptions::default());
 		let mut subxt = api.subxt();
 
-		let head = subxt.get_block_head(RPC_NODE_URL, None).await.unwrap().unwrap();
+		let head = subxt.get_block_head(&node_url, None).await.unwrap().unwrap();
 
-		assert!(!subxt.get_backing_groups(RPC_NODE_URL, head.hash()).await.unwrap().is_empty())
+		assert!(!subxt.get_backing_groups(&node_url, head.hash()).await.unwrap().is_empty())
 	}
 }


### PR DESCRIPTION
@alvicsam give it a try :-) 
We need to add RPC_NODE_URL to env vars