### PR TITLE
Use dynamic api for metadata-sensitive subxt calls

### DIFF
--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -15,10 +15,10 @@ pub(crate) fn decode_dynamic_validator_groups(
 	raw_groups: &Value<u32>,
 ) -> Result<Vec<Vec<ValidatorIndex>>, SubxtWrapperError> {
 	let decoded_groups = decode_vector(raw_groups)?;
-	let mut groups = vec![];
+	let mut groups = Vec::with_capacity(decoded_groups.len());
 	for raw_group in decoded_groups.iter() {
 		let decoded_group = decode_vector(raw_group)?;
-		let mut group = vec![];
+		let mut group = Vec::with_capacity(decoded_group.len());
 		for raw_index in decoded_group.iter() {
 			group.push(ValidatorIndex(decode_u128_value(raw_index)? as u32));
 		}
@@ -32,7 +32,7 @@ pub(crate) fn decode_dynamic_availability_cores(
 	raw_cores: &Value<u32>,
 ) -> Result<Vec<Option<CoreOccupied>>, SubxtWrapperError> {
 	let decoded_cores = decode_vector(raw_cores)?;
-	let mut cores = vec![];
+	let mut cores = Vec::with_capacity(decoded_cores.len());
 	for raw_core in decoded_cores.iter() {
 		cores.push(decode_option(raw_core)?.map(|v| match decode_variant(v).unwrap().name.as_str() {
 			"Parachain" => CoreOccupied::Parachain,
@@ -45,7 +45,7 @@ pub(crate) fn decode_dynamic_availability_cores(
 
 pub(crate) fn decode_dynamic_scheduled_paras(raw_paras: &Value<u32>) -> Result<Vec<CoreAssignment>, SubxtWrapperError> {
 	let decoded_paras = decode_vector(raw_paras)?;
-	let mut paras = vec![];
+	let mut paras = Vec::with_capacity(decoded_paras.len());
 	for para in decoded_paras.iter() {
 		let core = CoreIndex(decode_u128_value(para.at("core").expect("Should be defined"))? as u32);
 		let para_id = Id(decode_u128_value(para.at("para_id").expect("Should be defined"))? as u32);

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -1,0 +1,47 @@
+use super::subxt_wrapper::SubxtWrapperError::{self, DecodeDynamicError};
+use crate::metadata::polkadot_primitives;
+use subxt::{
+	dynamic::Value,
+	ext::scale_value::{Composite, Primitive, ValueDef},
+};
+
+pub(crate) fn decode_dynamic_validator_groups(
+	raw_groups: &Value<u32>,
+) -> Result<Vec<Vec<polkadot_primitives::ValidatorIndex>>, SubxtWrapperError> {
+	let decoded_groups = decode_validator_groups_value(raw_groups)?;
+	let mut groups = vec![];
+	for raw_group in decoded_groups.iter() {
+		let decoded_group = decode_validator_group_value(raw_group)?;
+		let mut group = vec![];
+		for raw_index in decoded_group.iter() {
+			group.push(decode_validator_index_value(raw_index)?)
+		}
+		groups.push(group)
+	}
+
+	Ok(groups)
+}
+
+fn decode_validator_groups_value(value: &Value<u32>) -> Result<&Vec<Value<u32>>, SubxtWrapperError> {
+	match &value.value {
+		ValueDef::Composite(Composite::Unnamed(v)) => Ok(v),
+		other => return Err(DecodeDynamicError("vector of validator groups".to_string(), other.clone())),
+	}
+}
+
+fn decode_validator_group_value(value: &Value<u32>) -> Result<&Vec<Value<u32>>, SubxtWrapperError> {
+	match &value.value {
+		ValueDef::Composite(Composite::Unnamed(v)) => Ok(v),
+		other => Err(DecodeDynamicError("vector of validator indices".to_string(), other.clone())),
+	}
+}
+
+fn decode_validator_index_value(value: &Value<u32>) -> Result<polkadot_primitives::ValidatorIndex, SubxtWrapperError> {
+	match &value.value {
+		ValueDef::Composite(Composite::Unnamed(v)) => match &v.first().expect("Expected a vector of one").value {
+			ValueDef::Primitive(Primitive::U128(index)) => Ok(polkadot_primitives::ValidatorIndex(*index as u32)),
+			other => Err(DecodeDynamicError("validator's index".to_string(), other.clone())),
+		},
+		other => Err(DecodeDynamicError("vector with validator's index".to_string(), other.clone())),
+	}
+}

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -35,7 +35,7 @@ pub(crate) fn decode_dynamic_availability_cores(
 	let decoded_cores = decode_vector(raw_cores)?;
 	let mut cores = Vec::with_capacity(decoded_cores.len());
 	for raw_core in decoded_cores.iter() {
-		let core = match decode_option(raw_core)?.map(|v| decode_variant(v)) {
+		let core = match decode_option(raw_core)?.map(decode_variant) {
 			Some(Ok(variant)) => match variant.name.as_str() {
 				"Parachain" => Some(CoreOccupied::Parachain),
 				name => todo!("Add support for {name}"),

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -1,17 +1,17 @@
 use super::subxt_wrapper::SubxtWrapperError::{self, DecodeDynamicError};
 use crate::metadata::polkadot_primitives;
 use subxt::{
-	dynamic::Value,
+	dynamic::{At, Value},
 	ext::scale_value::{Composite, Primitive, ValueDef},
 };
 
 pub(crate) fn decode_dynamic_validator_groups(
 	raw_groups: &Value<u32>,
 ) -> Result<Vec<Vec<polkadot_primitives::ValidatorIndex>>, SubxtWrapperError> {
-	let decoded_groups = decode_validator_groups_value(raw_groups)?;
+	let decoded_groups = decode_vector(raw_groups)?;
 	let mut groups = vec![];
 	for raw_group in decoded_groups.iter() {
-		let decoded_group = decode_validator_group_value(raw_group)?;
+		let decoded_group = decode_vector(raw_group)?;
 		let mut group = vec![];
 		for raw_index in decoded_group.iter() {
 			group.push(decode_validator_index_value(raw_index)?)
@@ -22,26 +22,41 @@ pub(crate) fn decode_dynamic_validator_groups(
 	Ok(groups)
 }
 
-fn decode_validator_groups_value(value: &Value<u32>) -> Result<&Vec<Value<u32>>, SubxtWrapperError> {
+fn decode_vector(value: &Value<u32>) -> Result<&Vec<Value<u32>>, SubxtWrapperError> {
 	match &value.value {
 		ValueDef::Composite(Composite::Unnamed(v)) => Ok(v),
-		other => return Err(DecodeDynamicError("vector of validator groups".to_string(), other.clone())),
+		other => return Err(DecodeDynamicError("vector".to_string(), other.clone())),
 	}
 }
 
-fn decode_validator_group_value(value: &Value<u32>) -> Result<&Vec<Value<u32>>, SubxtWrapperError> {
-	match &value.value {
-		ValueDef::Composite(Composite::Unnamed(v)) => Ok(v),
-		other => Err(DecodeDynamicError("vector of validator indices".to_string(), other.clone())),
+fn decode_option(value: &Value<u32>) -> Result<Option<&Value<u32>>, SubxtWrapperError> {
+	if matches!(value, Value { value: ValueDef::Variant(_), .. }) {
+		Ok(value.at(0))
+	} else {
+		Err(DecodeDynamicError("vector of validator indices".to_string(), value.value.clone()))
 	}
 }
 
 fn decode_validator_index_value(value: &Value<u32>) -> Result<polkadot_primitives::ValidatorIndex, SubxtWrapperError> {
-	match &value.value {
-		ValueDef::Composite(Composite::Unnamed(v)) => match &v.first().expect("Expected a vector of one").value {
-			ValueDef::Primitive(Primitive::U128(index)) => Ok(polkadot_primitives::ValidatorIndex(*index as u32)),
-			other => Err(DecodeDynamicError("validator's index".to_string(), other.clone())),
-		},
-		other => Err(DecodeDynamicError("vector with validator's index".to_string(), other.clone())),
+	match &decode_vector(value)?.first().expect("Expected a vector of one").value {
+		ValueDef::Primitive(Primitive::U128(index)) => Ok(polkadot_primitives::ValidatorIndex(*index as u32)),
+		other => Err(DecodeDynamicError("validator's index".to_string(), other.clone())),
 	}
+}
+
+pub(crate) fn decode_dynamic_availability_cores(
+	raw_cores: &Value<u32>,
+) -> Result<Vec<Option<polkadot_primitives::CoreOccupied>>, SubxtWrapperError> {
+	let decoded_cores = decode_vector(raw_cores)?;
+	let mut cores = vec![];
+	for row_core in decoded_cores.iter() {
+		cores.push(decode_core_occupied(row_core)?);
+	}
+
+	Ok(cores)
+}
+
+// TODO: Add support for on demand parachains
+fn decode_core_occupied(value: &Value<u32>) -> Result<Option<polkadot_primitives::CoreOccupied>, SubxtWrapperError> {
+	Ok(decode_option(value)?.map(|_| polkadot_primitives::CoreOccupied::Parachain))
 }

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -63,9 +63,9 @@ pub(crate) fn decode_dynamic_scheduled_paras(raw_paras: &Value<u32>) -> Result<V
 }
 
 fn value_at<'a>(field: &'a str, value: &'a Value<u32>) -> Result<&'a Value<u32>, SubxtWrapperError> {
-	Ok(value
+	value
 		.at(field)
-		.ok_or(DecodeDynamicError(format!(".{field}"), value.value.clone()))?)
+		.ok_or(DecodeDynamicError(format!(".{field}"), value.value.clone()))
 }
 
 fn decode_variant(value: &Value<u32>) -> Result<&Variant<u32>, SubxtWrapperError> {

--- a/essentials/src/api/mod.rs
+++ b/essentials/src/api/mod.rs
@@ -15,6 +15,7 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+mod dynamic;
 mod storage;
 pub mod subxt_wrapper;
 
@@ -148,7 +149,9 @@ mod tests {
 		let mut subxt = api.subxt();
 
 		let head = subxt.get_block_head(RPC_NODE_URL, None).await.unwrap().unwrap();
+		let groups = subxt.get_backing_groups(RPC_NODE_URL, head.hash()).await.unwrap();
 
-		assert!(!subxt.get_backing_groups(RPC_NODE_URL, head.hash()).await.unwrap().is_empty())
+		assert!(!groups.is_empty());
+		assert_eq!(groups[0][0].0, 0); // First validator's index is 0
 	}
 }

--- a/essentials/src/api/mod.rs
+++ b/essentials/src/api/mod.rs
@@ -77,7 +77,14 @@ where
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{metadata::polkadot_primitives::CoreOccupied, storage::StorageEntry, types::H256};
+	use crate::{
+		metadata::{
+			polkadot::runtime_types::polkadot_runtime_parachains::scheduler::CoreAssignment,
+			polkadot_primitives::CoreOccupied,
+		},
+		storage::StorageEntry,
+		types::H256,
+	};
 	use subxt::config::{substrate::BlakeTwo256, Hasher, Header};
 	#[cfg(feature = "rococo")]
 	const RPC_NODE_URL: &str = "wss://rococo-rpc.polkadot.io:443";
@@ -129,8 +136,10 @@ mod tests {
 		let mut subxt = api.subxt();
 
 		let head = subxt.get_block_head(RPC_NODE_URL, None).await.unwrap().unwrap();
+		let paras = subxt.get_scheduled_paras(RPC_NODE_URL, head.hash()).await.unwrap();
 
-		assert!(!subxt.get_scheduled_paras(RPC_NODE_URL, head.hash()).await.unwrap().is_empty())
+		assert!(!paras.is_empty());
+		assert!(matches!(paras[0], CoreAssignment { .. }));
 	}
 
 	#[tokio::test]

--- a/essentials/src/api/mod.rs
+++ b/essentials/src/api/mod.rs
@@ -77,7 +77,7 @@ where
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::{storage::StorageEntry, types::H256};
+	use crate::{metadata::polkadot_primitives::CoreOccupied, storage::StorageEntry, types::H256};
 	use subxt::config::{substrate::BlakeTwo256, Hasher, Header};
 	#[cfg(feature = "rococo")]
 	const RPC_NODE_URL: &str = "wss://rococo-rpc.polkadot.io:443";
@@ -139,8 +139,10 @@ mod tests {
 		let mut subxt = api.subxt();
 
 		let head = subxt.get_block_head(RPC_NODE_URL, None).await.unwrap().unwrap();
+		let cores = subxt.get_occupied_cores(RPC_NODE_URL, head.hash()).await.unwrap();
 
-		assert!(!subxt.get_occupied_cores(RPC_NODE_URL, head.hash()).await.unwrap().is_empty())
+		assert!(!cores.is_empty());
+		assert!(matches!(cores[0], Some(CoreOccupied::Parachain)) || matches!(cores[0], None))
 	}
 
 	#[tokio::test]

--- a/essentials/src/api/subxt_wrapper.rs
+++ b/essentials/src/api/subxt_wrapper.rs
@@ -17,6 +17,7 @@
 
 use super::dynamic::decode_dynamic_validator_groups;
 use crate::{
+	api::dynamic::decode_dynamic_availability_cores,
 	metadata::{polkadot, polkadot_primitives},
 	types::{AccountId32, BlockNumber, SessionKeys, SubxtCall, Timestamp, H256},
 	utils::{Retry, RetryOptions},
@@ -524,9 +525,10 @@ async fn subxt_get_sheduled_paras(api: &OnlineClient<PolkadotConfig>, block_hash
 }
 
 async fn subxt_get_occupied_cores(api: &OnlineClient<PolkadotConfig>, block_hash: H256) -> Result {
-	let addr = polkadot::storage().para_scheduler().availability_cores();
-	let occupied_cores = api.storage().at(block_hash).fetch(&addr).await?.unwrap_or_default();
-	Ok(Response::OccupiedCores(occupied_cores))
+	let addr = subxt::dynamic::storage_root("ParaScheduler", "AvailabilityCores");
+	let value = api.storage().at(block_hash).fetch(&addr).await?.unwrap().to_value()?;
+
+	Ok(Response::OccupiedCores(decode_dynamic_availability_cores(&value)?))
 }
 
 async fn subxt_get_validator_groups(api: &OnlineClient<PolkadotConfig>, block_hash: H256) -> Result {

--- a/essentials/src/api/subxt_wrapper.rs
+++ b/essentials/src/api/subxt_wrapper.rs
@@ -520,7 +520,10 @@ fn decode_extrinsic(data: &mut &[u8]) -> std::result::Result<SubxtCall, DecodeEx
 
 async fn subxt_get_sheduled_paras(api: &OnlineClient<PolkadotConfig>, block_hash: H256) -> Result {
 	let addr = subxt::dynamic::storage_root("ParaScheduler", "Scheduled");
-	let value = api.storage().at(block_hash).fetch(&addr).await?.unwrap().to_value()?;
+	let value = match api.storage().at(block_hash).fetch(&addr).await? {
+		Some(v) => v.to_value()?,
+		None => return Err(SubxtWrapperError::NoResponseFromDynamicApi),
+	};
 	let paras = decode_dynamic_scheduled_paras(&value)?;
 
 	Ok(Response::ScheduledParas(paras))
@@ -528,7 +531,10 @@ async fn subxt_get_sheduled_paras(api: &OnlineClient<PolkadotConfig>, block_hash
 
 async fn subxt_get_occupied_cores(api: &OnlineClient<PolkadotConfig>, block_hash: H256) -> Result {
 	let addr = subxt::dynamic::storage_root("ParaScheduler", "AvailabilityCores");
-	let value = api.storage().at(block_hash).fetch(&addr).await?.unwrap().to_value()?;
+	let value = match api.storage().at(block_hash).fetch(&addr).await? {
+		Some(v) => v.to_value()?,
+		None => return Err(SubxtWrapperError::NoResponseFromDynamicApi),
+	};
 	let cores = decode_dynamic_availability_cores(&value)?;
 
 	Ok(Response::OccupiedCores(cores))
@@ -536,7 +542,10 @@ async fn subxt_get_occupied_cores(api: &OnlineClient<PolkadotConfig>, block_hash
 
 async fn subxt_get_validator_groups(api: &OnlineClient<PolkadotConfig>, block_hash: H256) -> Result {
 	let addr = subxt::dynamic::storage_root("ParaScheduler", "ValidatorGroups");
-	let value = api.storage().at(block_hash).fetch(&addr).await?.unwrap().to_value()?;
+	let value = match api.storage().at(block_hash).fetch(&addr).await? {
+		Some(v) => v.to_value()?,
+		None => return Err(SubxtWrapperError::NoResponseFromDynamicApi),
+	};
 	let groups = decode_dynamic_validator_groups(&value)?;
 
 	Ok(Response::BackingGroups(groups))
@@ -653,7 +662,11 @@ async fn subxt_get_hrmp_content(
 
 async fn subxt_get_host_configuration(api: &OnlineClient<PolkadotConfig>) -> Result {
 	let addr = subxt::dynamic::storage_root("Configuration", "ActiveConfig");
-	let value = api.storage().at_latest().await?.fetch(&addr).await?.unwrap().to_value()?;
+	let value = match api.storage().at_latest().await?.fetch(&addr).await? {
+		Some(v) => v.to_value()?,
+		None => return Err(SubxtWrapperError::NoResponseFromDynamicApi),
+	};
+
 	Ok(Response::HostConfiguration(DynamicHostConfiguration::new(value)))
 }
 
@@ -690,6 +703,8 @@ pub enum SubxtWrapperError {
 	ConnectionError,
 	#[error("decode extinisc error")]
 	DecodeExtrinsicError,
+	#[error("no response from dynamic api")]
+	NoResponseFromDynamicApi,
 	#[error("decode dynamic value error: expected `{0}`, got {1}")]
 	DecodeDynamicError(String, ValueDef<u32>),
 }


### PR DESCRIPTION
Related to https://github.com/paritytech/polkadot-introspector/issues/381

These three methods are metadata-sensitive. I made them use the dynamic API, adding some decoding rules.