### PR TITLE
Move out responsibility for the launching from EventStream

### DIFF
--- a/essentials/src/consumer.rs
+++ b/essentials/src/consumer.rs
@@ -24,14 +24,11 @@ use tokio::sync::broadcast::Sender as BroadcastSender;
 pub trait EventStream {
 	type Event;
 
+	/// Create a consumer config
 	fn create_consumer(&mut self) -> EventConsumerInit<Self::Event>;
-	/// Run the main event loop.
-	async fn run(
-		self,
-		tasks: Vec<tokio::task::JoinHandle<()>>,
-		shutdown_tx: BroadcastSender<()>,
-		shutdown_future: tokio::task::JoinHandle<()>,
-	) -> color_eyre::Result<()>;
+
+	/// Prepare futures to join.
+	async fn run(self, shutdown_tx: &BroadcastSender<()>) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>>;
 }
 
 #[derive(Debug)]

--- a/whois/src/main.rs
+++ b/whois/src/main.rs
@@ -26,7 +26,6 @@ use polkadot_introspector_essentials::{
 };
 use polkadot_introspector_priority_channel::Receiver;
 use std::str::FromStr;
-use tokio::sync::broadcast;
 
 #[derive(Clone, Debug, Parser)]
 #[clap(author, version, about = "Simple telemetry feed")]


### PR DESCRIPTION
This way we can run more than one subscription, like to add telemetry feed to parachain-tracer