### PR TITLE
Prevent breaking changes after on-demand parachains released

### DIFF
--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -91,7 +91,6 @@ pub(crate) fn decode_dynamic_claim_queue(raw: &Value<u32>) -> Result<ClaimQueue,
 					.expect("Must contain option")
 					.map(|v| decode_paras_entry(v).expect("Must contain ParasEntry"))
 			})
-			.map(|v| v)
 			.collect();
 		let _ = claim_queue.insert(decoded_core, decoded_para_entries);
 	}

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -80,9 +80,8 @@ pub(crate) fn decode_dynamic_claim_queue(raw: &Value<u32>) -> Result<ClaimQueue,
 	let decoded_btree_map_inner = decoded_btree_map
 		.first()
 		.ok_or(SubxtWrapperError::DecodeDynamicError("ClaimQueue".to_string(), raw.value.clone()))?;
-	let decoded_values = decode_unnamed_composite(decoded_btree_map_inner)?;
 	let mut claim_queue: ClaimQueue = BTreeMap::new();
-	for value in decoded_values {
+	for value in decode_unnamed_composite(decoded_btree_map_inner)? {
 		let (raw_core, raw_para_entries) = match decode_unnamed_composite(value)?[..] {
 			[ref first, ref second, ..] => (first, second),
 			_ =>

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -1,12 +1,16 @@
 use super::subxt_wrapper::SubxtWrapperError::{self, DecodeDynamicError};
-use crate::metadata::{
-	polkadot::runtime_types::{
-		polkadot_parachain::primitives::Id,
-		polkadot_runtime_parachains::scheduler::{AssignmentKind, CoreAssignment},
+use crate::{
+	metadata::{
+		polkadot::runtime_types::{
+			polkadot_parachain::primitives::Id,
+			polkadot_runtime_parachains::scheduler::{AssignmentKind, CoreAssignment},
+		},
+		polkadot_primitives::{CoreIndex, CoreOccupied, GroupIndex, ValidatorIndex},
 	},
-	polkadot_primitives::{CoreIndex, CoreOccupied, GroupIndex, ValidatorIndex},
+	types::{Assignment, BlockNumber, ClaimQueue, ParasEntry},
 };
 use log::error;
+use std::collections::BTreeMap;
 use subxt::{
 	dynamic::{At, Value},
 	ext::scale_value::{Composite, Primitive, ValueDef, Variant},
@@ -15,13 +19,13 @@ use subxt::{
 pub(crate) fn decode_dynamic_validator_groups(
 	raw_groups: &Value<u32>,
 ) -> Result<Vec<Vec<ValidatorIndex>>, SubxtWrapperError> {
-	let decoded_groups = decode_vector(raw_groups)?;
+	let decoded_groups = decode_unnamed_composite(raw_groups)?;
 	let mut groups = Vec::with_capacity(decoded_groups.len());
 	for raw_group in decoded_groups.iter() {
-		let decoded_group = decode_vector(raw_group)?;
+		let decoded_group = decode_unnamed_composite(raw_group)?;
 		let mut group = Vec::with_capacity(decoded_group.len());
 		for raw_index in decoded_group.iter() {
-			group.push(ValidatorIndex(decode_u128_value(raw_index)? as u32));
+			group.push(ValidatorIndex(decode_composite_u128_value(raw_index)? as u32));
 		}
 		groups.push(group)
 	}
@@ -32,7 +36,7 @@ pub(crate) fn decode_dynamic_validator_groups(
 pub(crate) fn decode_dynamic_availability_cores(
 	raw_cores: &Value<u32>,
 ) -> Result<Vec<Option<CoreOccupied>>, SubxtWrapperError> {
-	let decoded_cores = decode_vector(raw_cores)?;
+	let decoded_cores = decode_unnamed_composite(raw_cores)?;
 	let mut cores = Vec::with_capacity(decoded_cores.len());
 	for raw_core in decoded_cores.iter() {
 		let core = match decode_option(raw_core)?.map(decode_variant) {
@@ -53,22 +57,55 @@ pub(crate) fn decode_dynamic_availability_cores(
 }
 
 pub(crate) fn decode_dynamic_scheduled_paras(raw_paras: &Value<u32>) -> Result<Vec<CoreAssignment>, SubxtWrapperError> {
-	let decoded_paras = decode_vector(raw_paras)?;
+	let decoded_paras = decode_unnamed_composite(raw_paras)?;
 	let mut paras = Vec::with_capacity(decoded_paras.len());
 	for para in decoded_paras.iter() {
-		let core = CoreIndex(decode_u128_value(value_at("core", para)?)? as u32);
-		let para_id = Id(decode_u128_value(value_at("para_id", para)?)? as u32);
+		let core = CoreIndex(decode_composite_u128_value(value_at("core", para)?)? as u32);
+		let para_id = Id(decode_composite_u128_value(value_at("para_id", para)?)? as u32);
 		let kind = match decode_variant(value_at("kind", para)?)?.name.as_str() {
 			"Parachain" => AssignmentKind::Parachain,
 			name => todo!("Add support for {name}"),
 		};
-		let group_idx = GroupIndex(decode_u128_value(value_at("group_idx", para)?)? as u32);
+		let group_idx = GroupIndex(decode_composite_u128_value(value_at("group_idx", para)?)? as u32);
 		let assignment = CoreAssignment { core, para_id, kind, group_idx };
 
 		paras.push(assignment)
 	}
 
 	Ok(paras)
+}
+
+pub(crate) fn decode_dynamic_claim_queue(raw: &Value<u32>) -> Result<ClaimQueue, SubxtWrapperError> {
+	let decoded_btree_map = decode_unnamed_composite(raw)?;
+	let decoded_values = decode_unnamed_composite(decoded_btree_map.first().expect("Must contain values"))?;
+	let mut claim_queue: ClaimQueue = BTreeMap::new();
+	for value in decoded_values {
+		let decoded_tuple = decode_unnamed_composite(value)?;
+		let raw_core = decoded_tuple.first().expect("Must contain core");
+		let raw_para_entries = decoded_tuple.last().expect("Must contain para_entry");
+		let decoded_core = decode_composite_u128_value(raw_core)? as u32;
+		let decoded_para_entries = decode_unnamed_composite(raw_para_entries)?
+			.iter()
+			.map(|v| {
+				decode_option(v)
+					.expect("Must contain option")
+					.map(|v| decode_paras_entry(v).expect("Must contain ParasEntry"))
+			})
+			.map(|v| v)
+			.collect();
+		let _ = claim_queue.insert(decoded_core, decoded_para_entries);
+	}
+	Ok(claim_queue)
+}
+
+fn decode_paras_entry(raw: &Value<u32>) -> Result<ParasEntry, SubxtWrapperError> {
+	Ok(ParasEntry {
+		assignment: Assignment {
+			para_id: decode_composite_u128_value(value_at("para_id", value_at("assignment", raw)?)?)? as u32,
+		},
+		retries: decode_u128_value(value_at("retries", raw)?)? as u32,
+		ttl: decode_u128_value(value_at("ttl", raw)?)? as BlockNumber,
+	})
 }
 
 fn value_at<'a>(field: &'a str, value: &'a Value<u32>) -> Result<&'a Value<u32>, SubxtWrapperError> {
@@ -92,19 +129,23 @@ fn decode_option(value: &Value<u32>) -> Result<Option<&Value<u32>>, SubxtWrapper
 	}
 }
 
-fn decode_vector(value: &Value<u32>) -> Result<&Vec<Value<u32>>, SubxtWrapperError> {
+fn decode_unnamed_composite(value: &Value<u32>) -> Result<&Vec<Value<u32>>, SubxtWrapperError> {
 	match &value.value {
 		ValueDef::Composite(Composite::Unnamed(v)) => Ok(v),
-		other => Err(DecodeDynamicError("vector".to_string(), other.clone())),
+		other => Err(DecodeDynamicError("unnamed composite".to_string(), other.clone())),
+	}
+}
+
+fn decode_composite_u128_value(value: &Value<u32>) -> Result<u128, SubxtWrapperError> {
+	match decode_unnamed_composite(value)?[..] {
+		[ref first, ..] => decode_u128_value(first),
+		_ => Err(DecodeDynamicError("vector of one element".to_string(), value.value.clone())),
 	}
 }
 
 fn decode_u128_value(value: &Value<u32>) -> Result<u128, SubxtWrapperError> {
-	match decode_vector(value)?[..] {
-		[ref first, ..] => match &first.value {
-			ValueDef::Primitive(Primitive::U128(v)) => Ok(*v),
-			other => Err(DecodeDynamicError("u128".to_string(), other.clone())),
-		},
-		_ => Err(DecodeDynamicError("vector of one element".to_string(), value.value.clone())),
+	match &value.value {
+		ValueDef::Primitive(Primitive::U128(v)) => Ok(*v),
+		other => Err(DecodeDynamicError("u128".to_string(), other.clone())),
 	}
 }

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -16,9 +16,7 @@ use subxt::{
 	ext::scale_value::{Composite, Primitive, ValueDef, Variant},
 };
 
-pub(crate) fn decode_dynamic_validator_groups(
-	raw_groups: &Value<u32>,
-) -> Result<Vec<Vec<ValidatorIndex>>, SubxtWrapperError> {
+pub(crate) fn decode_validator_groups(raw_groups: &Value<u32>) -> Result<Vec<Vec<ValidatorIndex>>, SubxtWrapperError> {
 	let decoded_groups = decode_unnamed_composite(raw_groups)?;
 	let mut groups = Vec::with_capacity(decoded_groups.len());
 	for raw_group in decoded_groups.iter() {
@@ -33,9 +31,7 @@ pub(crate) fn decode_dynamic_validator_groups(
 	Ok(groups)
 }
 
-pub(crate) fn decode_dynamic_availability_cores(
-	raw_cores: &Value<u32>,
-) -> Result<Vec<CoreOccupied>, SubxtWrapperError> {
+pub(crate) fn decode_availability_cores(raw_cores: &Value<u32>) -> Result<Vec<CoreOccupied>, SubxtWrapperError> {
 	let decoded_cores = decode_unnamed_composite(raw_cores)?;
 	let mut cores = Vec::with_capacity(decoded_cores.len());
 	for raw_core in decoded_cores.iter() {
@@ -63,7 +59,7 @@ pub(crate) fn decode_dynamic_availability_cores(
 	Ok(cores)
 }
 
-pub(crate) fn decode_dynamic_scheduled_paras(raw_paras: &Value<u32>) -> Result<Vec<CoreAssignment>, SubxtWrapperError> {
+pub(crate) fn decode_scheduled_paras(raw_paras: &Value<u32>) -> Result<Vec<CoreAssignment>, SubxtWrapperError> {
 	let decoded_paras = decode_unnamed_composite(raw_paras)?;
 	let mut paras = Vec::with_capacity(decoded_paras.len());
 	for para in decoded_paras.iter() {
@@ -82,7 +78,7 @@ pub(crate) fn decode_dynamic_scheduled_paras(raw_paras: &Value<u32>) -> Result<V
 	Ok(paras)
 }
 
-pub(crate) fn decode_dynamic_claim_queue(raw: &Value<u32>) -> Result<ClaimQueue, SubxtWrapperError> {
+pub(crate) fn decode_claim_queue(raw: &Value<u32>) -> Result<ClaimQueue, SubxtWrapperError> {
 	let decoded_btree_map = decode_unnamed_composite(raw)?;
 	let decoded_btree_map_inner = decoded_btree_map
 		.first()

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -46,9 +46,9 @@ pub(crate) fn decode_dynamic_availability_cores(
 		};
 		let core = match core_variant.map(decode_variant) {
 			Some(Ok(variant)) => match variant.name.as_str() {
-				"Parachain" => CoreOccupied::Paras,
-				"Paras" => CoreOccupied::Paras,
-				"Free" => CoreOccupied::Free,
+				"Parachain" => CoreOccupied::Paras, // v4
+				"Paras" => CoreOccupied::Paras,     // v5
+				"Free" => CoreOccupied::Free,       // v5
 				name => todo!("Add support for {name}"),
 			},
 			Some(Err(e)) => {

--- a/essentials/src/api/subxt_wrapper.rs
+++ b/essentials/src/api/subxt_wrapper.rs
@@ -55,6 +55,7 @@ pub enum RequestType {
 	/// Get the availability core scheduling information at a given block.
 	GetScheduledParas(<PolkadotConfig as subxt::Config>::Hash),
 	/// TODO: Fill
+	/// Get the claim queue scheduling information at a given block.
 	GetClaimQueue(<PolkadotConfig as subxt::Config>::Hash),
 	/// Get occupied core information at a given block.
 	GetOccupiedCores(<PolkadotConfig as subxt::Config>::Hash),
@@ -171,7 +172,7 @@ pub enum Response {
 	ParaInherentData(InherentData),
 	/// Availability core assignments for parachains.
 	ScheduledParas(Vec<polkadot::runtime_types::polkadot_runtime_parachains::scheduler::CoreAssignment>),
-	/// TODO: Fill
+	/// Claim queue for parachains.
 	ClaimQueue(ClaimQueue),
 	/// List of the occupied availability cores.
 	OccupiedCores(Vec<CoreOccupied>),

--- a/essentials/src/api/subxt_wrapper.rs
+++ b/essentials/src/api/subxt_wrapper.rs
@@ -15,9 +15,9 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-use super::dynamic::{decode_dynamic_claim_queue, decode_dynamic_validator_groups};
+use super::dynamic::{decode_claim_queue, decode_validator_groups};
 use crate::{
-	api::dynamic::{decode_dynamic_availability_cores, decode_dynamic_scheduled_paras},
+	api::dynamic::{decode_availability_cores, decode_scheduled_paras},
 	metadata::{polkadot, polkadot_primitives},
 	types::{AccountId32, BlockNumber, ClaimQueue, CoreOccupied, SessionKeys, Timestamp, H256},
 	utils::{Retry, RetryOptions},
@@ -536,28 +536,28 @@ async fn fetch_dynamic_storage(
 
 async fn subxt_get_sheduled_paras(api: &OnlineClient<PolkadotConfig>, block_hash: H256) -> Result {
 	let value = fetch_dynamic_storage(api, block_hash, "ParaScheduler", "Scheduled").await?;
-	let paras = decode_dynamic_scheduled_paras(&value)?;
+	let paras = decode_scheduled_paras(&value)?;
 
 	Ok(Response::ScheduledParas(paras))
 }
 
 async fn subxt_get_claim_queue(api: &OnlineClient<PolkadotConfig>, block_hash: H256) -> Result {
 	let value = fetch_dynamic_storage(api, block_hash, "ParaScheduler", "ClaimQueue").await?;
-	let queue = decode_dynamic_claim_queue(&value)?;
+	let queue = decode_claim_queue(&value)?;
 
 	Ok(Response::ClaimQueue(queue))
 }
 
 async fn subxt_get_occupied_cores(api: &OnlineClient<PolkadotConfig>, block_hash: H256) -> Result {
 	let value = fetch_dynamic_storage(api, block_hash, "ParaScheduler", "AvailabilityCores").await?;
-	let cores = decode_dynamic_availability_cores(&value)?;
+	let cores = decode_availability_cores(&value)?;
 
 	Ok(Response::OccupiedCores(cores))
 }
 
 async fn subxt_get_validator_groups(api: &OnlineClient<PolkadotConfig>, block_hash: H256) -> Result {
 	let value = fetch_dynamic_storage(api, block_hash, "ParaScheduler", "ValidatorGroups").await?;
-	let groups = decode_dynamic_validator_groups(&value)?;
+	let groups = decode_validator_groups(&value)?;
 
 	Ok(Response::BackingGroups(groups))
 }

--- a/essentials/src/api/subxt_wrapper.rs
+++ b/essentials/src/api/subxt_wrapper.rs
@@ -19,7 +19,7 @@ use super::dynamic::{decode_dynamic_claim_queue, decode_dynamic_validator_groups
 use crate::{
 	api::dynamic::{decode_dynamic_availability_cores, decode_dynamic_scheduled_paras},
 	metadata::{polkadot, polkadot_primitives},
-	types::{AccountId32, BlockNumber, ClaimQueue, SessionKeys, Timestamp, H256},
+	types::{AccountId32, BlockNumber, ClaimQueue, CoreOccupied, SessionKeys, Timestamp, H256},
 	utils::{Retry, RetryOptions},
 };
 use log::error;
@@ -174,7 +174,7 @@ pub enum Response {
 	/// TODO: Fill
 	ClaimQueue(ClaimQueue),
 	/// List of the occupied availability cores.
-	OccupiedCores(Vec<Option<polkadot_primitives::CoreOccupied>>),
+	OccupiedCores(Vec<CoreOccupied>),
 	/// Backing validator groups.
 	BackingGroups(Vec<Vec<polkadot_primitives::ValidatorIndex>>),
 	/// Returns a session index
@@ -364,7 +364,7 @@ impl RequestExecutor {
 		&mut self,
 		url: &str,
 		block_hash: <PolkadotConfig as subxt::Config>::Hash,
-	) -> std::result::Result<Vec<Option<polkadot_primitives::CoreOccupied>>, SubxtWrapperError> {
+	) -> std::result::Result<Vec<CoreOccupied>, SubxtWrapperError> {
 		wrap_subxt_call!(self, GetOccupiedCores, OccupiedCores, url, block_hash)
 	}
 

--- a/essentials/src/types.rs
+++ b/essentials/src/types.rs
@@ -35,7 +35,8 @@ pub type SubxtCall = runtime::RuntimeCall;
 
 pub type ClaimQueue = BTreeMap<u32, VecDeque<Option<ParasEntry>>>;
 
-// TODO: Take it from runtime types
+// TODO: Take it from runtime types v5
+/// Polkadot v5 ParasEntry type
 #[derive(Debug)]
 pub struct ParasEntry {
 	/// The `Assignment`
@@ -46,9 +47,20 @@ pub struct ParasEntry {
 	pub ttl: BlockNumber,
 }
 
-// TODO: Take it from runtime types
+// TODO: Take it from runtime types v5
+/// Polkadot v5 Assignment type
 #[derive(Debug)]
 pub struct Assignment {
 	/// Assignment's ParaId
 	pub para_id: u32,
+}
+
+// TODO: Take it from runtime types v5
+/// Temporary abstraction to cover core state until v5 types are released
+#[derive(Debug)]
+pub enum CoreOccupied {
+	/// The core is not occupied.
+	Free,
+	/// A paras.
+	Paras,
 }

--- a/essentials/src/types.rs
+++ b/essentials/src/types.rs
@@ -16,6 +16,7 @@
 //
 
 use crate::metadata::polkadot::runtime_types as subxt_runtime_types;
+use std::collections::{BTreeMap, VecDeque};
 use subxt::utils;
 
 #[cfg(feature = "kusama")]
@@ -31,3 +32,23 @@ pub type AccountId32 = utils::AccountId32;
 pub type Timestamp = u64;
 pub type SessionKeys = runtime::SessionKeys;
 pub type SubxtCall = runtime::RuntimeCall;
+
+pub type ClaimQueue = BTreeMap<u32, VecDeque<Option<ParasEntry>>>;
+
+// TODO: Take it from runtime types
+#[derive(Debug)]
+pub struct ParasEntry {
+	/// The `Assignment`
+	pub assignment: Assignment,
+	/// Number of times this has been retried.
+	pub retries: u32,
+	/// The block height where this entry becomes invalid.
+	pub ttl: BlockNumber,
+}
+
+// TODO: Take it from runtime types
+#[derive(Debug)]
+pub struct Assignment {
+	/// Assignment's ParaId
+	pub para_id: u32,
+}

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -558,7 +558,6 @@ impl SubxtTracker {
 					.collect::<Vec<_>>();
 				(*core, ids)
 			})
-			.map(|v| v)
 			.collect())
 	}
 

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -26,7 +26,7 @@ use polkadot_introspector_essentials::{
 	api::subxt_wrapper::{InherentData, RequestExecutor, SubxtHrmpChannel, SubxtWrapperError},
 	chain_events::SubxtDisputeResult,
 	collector::{candidate_record::CandidateRecord, CollectorPrefixType, CollectorStorageApi, DisputeInfo},
-	metadata::{polkadot, polkadot_primitives},
+	metadata::polkadot_primitives,
 	types::{AccountId32, BlockNumber, CoreOccupied, Timestamp, H256},
 };
 use std::{


### PR DESCRIPTION
On-demand Parachains shows up with some type changes. In that PR I added some new types, which could be not exact as the original ones, but they're enough to make tracer work. We need to replace them with original ones as they're released in v5.