### PR TITLE
Take down the tracer on the collector termination

### DIFF
--- a/parachain-tracer/src/main.rs
+++ b/parachain-tracer/src/main.rs
@@ -232,8 +232,9 @@ impl ParachainTracer {
 							tracker.new_session(idx).await;
 						},
 						CollectorUpdateEvent::Termination => {
-							info!("collector is terminating");
-							break
+							error!("collector is terminating");
+							// We can no longer follow the chain
+							std::process::exit(1);
 						},
 					},
 					Err(_) => {

--- a/parachain-tracer/src/main.rs
+++ b/parachain-tracer/src/main.rs
@@ -236,6 +236,7 @@ impl ParachainTracer {
 							if code != 0 {
 								std::process::exit(code)
 							};
+							break
 						},
 					},
 					Err(_) => {
@@ -306,6 +307,7 @@ impl ParachainTracer {
 								if code != 0 {
 									std::process::exit(code)
 								};
+								break
 							},
 						},
 						None => {

--- a/parachain-tracer/src/main.rs
+++ b/parachain-tracer/src/main.rs
@@ -231,10 +231,11 @@ impl ParachainTracer {
 						CollectorUpdateEvent::NewSession(idx) => {
 							tracker.new_session(idx).await;
 						},
-						CollectorUpdateEvent::Termination => {
-							error!("collector is terminating");
-							// We can no longer follow the chain
-							std::process::exit(1);
+						CollectorUpdateEvent::Termination(code) => {
+							info!("collector is terminating");
+							if code != 0 {
+								std::process::exit(code)
+							};
 						},
 					},
 					Err(_) => {
@@ -299,10 +300,12 @@ impl ParachainTracer {
 								for to_tracker in trackers.values_mut() {
 									to_tracker.send(CollectorUpdateEvent::NewSession(idx)).await.unwrap();
 								},
-							CollectorUpdateEvent::Termination => {
+							CollectorUpdateEvent::Termination(code) => {
 								info!("Received termination event, {} trackers will be terminated, {} futures are pending",
 									trackers.len(), futures.len());
-								break;
+								if code != 0 {
+									std::process::exit(code)
+								};
 							},
 						},
 						None => {


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-introspector/issues/483

We should take down the entire tracer on the collector termination to allow k8s to restart the pod. 