### PR TITLE
Track on-demand orders 

### DIFF
--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -101,7 +101,7 @@ pub(crate) fn decode_claim_queue(raw: &Value<u32>) -> Result<ClaimQueue, SubxtWr
 	Ok(claim_queue)
 }
 
-pub(crate) fn decode_on_demand_order_placed(raw: &Composite<u32>) -> Result<OnDemandOrder, SubxtWrapperError> {
+pub(crate) fn decode_on_demand_order(raw: &Composite<u32>) -> Result<OnDemandOrder, SubxtWrapperError> {
 	match raw {
 		Composite::Named(v) => {
 			let raw_para_id = v

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -6,7 +6,7 @@ use crate::{
 		},
 		polkadot_primitives::{CoreIndex, ValidatorIndex},
 	},
-	types::{Assignment, BlockNumber, ClaimQueue, CoreAssignment, CoreOccupied, ParasEntry},
+	types::{Assignment, BlockNumber, ClaimQueue, CoreAssignment, CoreOccupied, OnDemandOrder, ParasEntry},
 };
 use log::error;
 use std::collections::{BTreeMap, VecDeque};
@@ -99,6 +99,34 @@ pub(crate) fn decode_claim_queue(raw: &Value<u32>) -> Result<ClaimQueue, SubxtWr
 		let _ = claim_queue.insert(decoded_core, paras_entries);
 	}
 	Ok(claim_queue)
+}
+
+pub(crate) fn decode_on_demand_order_placed(raw: &Composite<u32>) -> Result<OnDemandOrder, SubxtWrapperError> {
+	match raw {
+		Composite::Named(v) => {
+			let raw_para_id = v
+				.iter()
+				.find_map(|(field, value)| if field == "para_id" { Some(value) } else { None })
+				.ok_or(SubxtWrapperError::DecodeDynamicError(
+					"named composite with field `para_id`".to_string(),
+					ValueDef::Composite(raw.clone()),
+				))?;
+			let raw_spot_price = v
+				.iter()
+				.find_map(|(field, value)| if field == "spot_price" { Some(value) } else { None })
+				.ok_or(SubxtWrapperError::DecodeDynamicError(
+					"named composite with field `spot_price`".to_string(),
+					ValueDef::Composite(raw.clone()),
+				))?;
+
+			Ok(OnDemandOrder {
+				para_id: decode_composite_u128_value(raw_para_id)? as u32,
+				spot_price: decode_u128_value(raw_spot_price)?,
+			})
+		},
+		_ =>
+			Err(SubxtWrapperError::DecodeDynamicError("named composite".to_string(), ValueDef::Composite(raw.clone()))),
+	}
 }
 
 fn decode_paras_entry_option(raw: &Value<u32>) -> Result<Option<ParasEntry>, SubxtWrapperError> {

--- a/essentials/src/api/mod.rs
+++ b/essentials/src/api/mod.rs
@@ -15,7 +15,7 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-mod dynamic;
+pub mod dynamic;
 mod storage;
 pub mod subxt_wrapper;
 

--- a/essentials/src/chain_events.rs
+++ b/essentials/src/chain_events.rs
@@ -16,7 +16,7 @@
 //
 
 use crate::{
-	api::dynamic::decode_on_demand_order_placed,
+	api::dynamic::decode_on_demand_order,
 	metadata::{
 		polkadot::{
 			para_inclusion::events::{CandidateBacked, CandidateIncluded, CandidateTimedOut},
@@ -149,7 +149,7 @@ pub async fn decode_chain_event<T: subxt::Config>(
 
 	// TODO: Use `is_specific_event` as soon as shows up in types
 	if event.pallet_name() == "OnDemandAssignmentProvider" && event.variant_name() == "OnDemandOrderPlaced" {
-		let decoded = decode_on_demand_order_placed(&event.field_values()?)?;
+		let decoded = decode_on_demand_order(&event.field_values()?)?;
 		return Ok(ChainEvent::OnDemandOrderPlaced(block_hash, decoded))
 	}
 

--- a/essentials/src/types.rs
+++ b/essentials/src/types.rs
@@ -22,6 +22,7 @@ use crate::metadata::{
 	},
 	polkadot_primitives::CoreIndex,
 };
+use parity_scale_codec::{Decode, Encode};
 use std::collections::{BTreeMap, VecDeque};
 use subxt::utils;
 
@@ -80,4 +81,12 @@ pub enum CoreOccupied {
 	Free,
 	/// A paras.
 	Paras,
+}
+
+// TODO: Take it from runtime types v5
+/// Temporary abstraction to cover `Event::OnDemandAssignmentProvider`
+#[derive(Debug, Decode, Encode)]
+pub struct OnDemandOrder {
+	pub para_id: u32,
+	pub spot_price: u128,
 }

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -154,6 +154,8 @@ pub struct SubxtTracker {
 	disputes: Vec<DisputesTracker>,
 	/// Current relay chain block timestamp.
 	current_relay_block_ts: Option<Timestamp>,
+	/// Current on-demand order
+	on_demand_order: Option<OnDemandOrder>,
 	/// Last observed finality lag
 	finality_lag: Option<u32>,
 	/// Last relay chain block timestamp.
@@ -247,15 +249,7 @@ impl ParachainBlockTracker for SubxtTracker {
 			error!("Failed to get inherent data for {:?}", block_hash);
 		}
 
-		if let Some(on_demand_order) = self
-			.api
-			.storage()
-			.storage_read_prefixed(CollectorPrefixType::OnDemandOrder(self.para_id), block_hash)
-			.await
-		{
-			let on_demand_order: OnDemandOrder = on_demand_order.into_inner().unwrap();
-			self.on_on_demand_order(on_demand_order).await?;
-		}
+		self.set_on_demand_order(block_hash).await;
 
 		Ok(&self.current_candidate)
 	}
@@ -353,6 +347,10 @@ impl ParachainBlockTracker for SubxtTracker {
 			metrics.on_block(tm.as_secs_f64(), self.para_id);
 		}
 
+		if let Some(ref order) = self.on_demand_order {
+			metrics.on_on_demand_order(order);
+		}
+
 		if let Some(finality_lag) = self.finality_lag {
 			metrics.on_finality_lag(finality_lag);
 		}
@@ -384,6 +382,7 @@ impl SubxtTracker {
 			current_relay_block: None,
 			previous_relay_block: None,
 			current_relay_block_ts: None,
+			on_demand_order: None,
 			finality_lag: None,
 			disputes: Vec::new(),
 			last_assignment: None,
@@ -400,6 +399,15 @@ impl SubxtTracker {
 	fn set_relay_block(&mut self, block_number: BlockNumber, block_hash: H256) {
 		self.previous_relay_block = self.current_relay_block;
 		self.current_relay_block = Some((block_number, block_hash));
+	}
+
+	async fn set_on_demand_order(&mut self, block_hash: H256) {
+		self.on_demand_order = self
+			.api
+			.storage()
+			.storage_read_prefixed(CollectorPrefixType::OnDemandOrder(self.para_id), block_hash)
+			.await
+			.map(|v| v.into_inner::<OnDemandOrder>().unwrap());
 	}
 
 	async fn get_session_keys(&self, session_index: u32) -> Option<Vec<AccountId32>> {
@@ -506,11 +514,6 @@ impl SubxtTracker {
 			}
 		}
 
-		Ok(())
-	}
-
-	async fn on_on_demand_order(&self, order: OnDemandOrder) -> color_eyre::Result<()> {
-		println!("order {:?}", order);
 		Ok(())
 	}
 

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -27,7 +27,7 @@ use polkadot_introspector_essentials::{
 	chain_events::SubxtDisputeResult,
 	collector::{candidate_record::CandidateRecord, CollectorPrefixType, CollectorStorageApi, DisputeInfo},
 	metadata::polkadot_primitives,
-	types::{AccountId32, BlockNumber, CoreOccupied, Timestamp, H256},
+	types::{AccountId32, BlockNumber, CoreOccupied, OnDemandOrder, Timestamp, H256},
 };
 use std::{
 	collections::{BTreeMap, HashMap},
@@ -245,6 +245,16 @@ impl ParachainBlockTracker for SubxtTracker {
 				.update_hrmp_channels(inbound_hrmp_channels, outbound_hrmp_channels);
 		} else {
 			error!("Failed to get inherent data for {:?}", block_hash);
+		}
+
+		if let Some(on_demand_order) = self
+			.api
+			.storage()
+			.storage_read_prefixed(CollectorPrefixType::OnDemandOrder(self.para_id), block_hash)
+			.await
+		{
+			let on_demand_order: OnDemandOrder = on_demand_order.into_inner().unwrap();
+			self.on_on_demand_order(on_demand_order).await?;
 		}
 
 		Ok(&self.current_candidate)
@@ -496,6 +506,11 @@ impl SubxtTracker {
 			}
 		}
 
+		Ok(())
+	}
+
+	async fn on_on_demand_order(&self, order: OnDemandOrder) -> color_eyre::Result<()> {
+		println!("order {:?}", order);
 		Ok(())
 	}
 


### PR DESCRIPTION
Part of https://github.com/paritytech/polkadot-introspector/issues/375
Added parsing events `OnDemandOrderPlaced`, bids go to Prometheus. Parsing is "custom" because we don't have right types in current metadata. 