### PR TITLE
Accept None from dynamic storage as a valid response

### DIFF
--- a/essentials/src/api/subxt_wrapper.rs
+++ b/essentials/src/api/subxt_wrapper.rs
@@ -528,7 +528,7 @@ async fn fetch_dynamic_storage(
 		.fetch(&subxt::dynamic::storage_root(pallet_name, entry_name))
 		.await?
 	{
-		Some(v) => v.to_value().map(|v| Some(v)).map_err(|e| e.into()),
+		Some(v) => v.to_value().map(Some).map_err(|e| e.into()),
 		None => Ok(None), // Value has not found in the storage
 	}
 }

--- a/essentials/src/api/subxt_wrapper.rs
+++ b/essentials/src/api/subxt_wrapper.rs
@@ -529,7 +529,7 @@ async fn fetch_dynamic_storage(
 		.await?
 	{
 		Some(v) => v.to_value().map(Some).map_err(|e| e.into()),
-		None => Ok(None), // Value has not found in the storage
+		None => Ok(None),
 	}
 }
 

--- a/parachain-tracer/src/main.rs
+++ b/parachain-tracer/src/main.rs
@@ -358,9 +358,12 @@ fn evict_stalled(
 }
 
 async fn print_host_configuration(url: &str, executor: &mut RequestExecutor) -> color_eyre::Result<()> {
-	let conf = executor.get_host_configuration(url).await?;
-	println!("Host configuration for {}:", url.to_owned().bold());
-	println!("{}", conf);
+	if let Some(conf) = executor.get_host_configuration(url).await? {
+		println!("Host configuration for {}:", url.to_owned().bold());
+		println!("{}", conf);
+	} else {
+		info!("Host configuration not found in storage");
+	}
 	Ok(())
 }
 


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-introspector/issues/545

Responses from dynamic storage contain optional value. `None` means that there is no value in the storage. It's not an error. For example, `ClaimQueue` may be `None` after a session change. 