### PR TITLE
Cache repeating rpc queries in the collector

### DIFF
--- a/essentials/src/collector/mod.rs
+++ b/essentials/src/collector/mod.rs
@@ -704,7 +704,6 @@ impl Collector {
 		block_hash: H256,
 	) -> color_eyre::Result<BTreeMap<u32, Vec<u32>>, SubxtWrapperError> {
 		let core_assignments = self.executor.get_scheduled_paras(self.endpoint.as_str(), block_hash).await?;
-
 		Ok(core_assignments
 			.iter()
 			.map(|v| (v.core.0, vec![v.para_id.0]))

--- a/essentials/src/types.rs
+++ b/essentials/src/types.rs
@@ -72,7 +72,7 @@ pub struct Assignment {
 
 // TODO: Take it from runtime types v5
 /// Temporary abstraction to cover core state until v5 types are released
-#[derive(Debug)]
+#[derive(Debug, Decode, Encode)]
 pub enum CoreOccupied {
 	/// The core is not occupied.
 	Free,

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -644,7 +644,7 @@ mod test_inject_block {
 		storage_write(CollectorPrefixType::InherentData, first_hash, create_inherent_data(100), &storage)
 			.await
 			.unwrap();
-		storage_write(CollectorPrefixType::Timestamp, first_hash, 1, &storage)
+		storage_write(CollectorPrefixType::Timestamp, first_hash, 1_u64, &storage)
 			.await
 			.unwrap();
 		tracker
@@ -655,17 +655,25 @@ mod test_inject_block {
 		let current = tracker.current_relay_block.unwrap();
 		assert!(tracker.previous_relay_block.is_none());
 		assert_eq!(current.hash, first_hash);
-		assert_eq!(tracker.last_non_fork_relay_block_ts, Some(1));
+		assert_eq!(tracker.last_non_fork_relay_block_ts, Some(1_u64));
 		assert!(tracker.finality_lag.is_none());
 
 		// Inject a fork and relevant finalized block number
+		storage_write(
+			CollectorPrefixType::CoreAssignments,
+			second_hash,
+			BTreeMap::<u32, Vec<u32>>::default(),
+			&storage,
+		)
+		.await
+		.unwrap();
 		storage_write(CollectorPrefixType::InherentData, second_hash, create_inherent_data(100), &storage)
 			.await
 			.unwrap();
 		storage_write(CollectorPrefixType::RelevantFinalizedBlockNumber, second_hash, 40, &storage)
 			.await
 			.unwrap();
-		storage_write(CollectorPrefixType::Timestamp, second_hash, 2, &storage)
+		storage_write(CollectorPrefixType::Timestamp, second_hash, 2_u64, &storage)
 			.await
 			.unwrap();
 		tracker

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -644,7 +644,7 @@ mod test_inject_block {
 		storage_write(CollectorPrefixType::InherentData, first_hash, create_inherent_data(100), &storage)
 			.await
 			.unwrap();
-		storage_write(CollectorPrefixType::Timestamp, first_hash, 1694095332, &storage)
+		storage_write(CollectorPrefixType::Timestamp, first_hash, 1, &storage)
 			.await
 			.unwrap();
 		tracker
@@ -655,7 +655,7 @@ mod test_inject_block {
 		let current = tracker.current_relay_block.unwrap();
 		assert!(tracker.previous_relay_block.is_none());
 		assert_eq!(current.hash, first_hash);
-		assert_eq!(tracker.last_non_fork_relay_block_ts, Some(1694095332));
+		assert_eq!(tracker.last_non_fork_relay_block_ts, Some(1));
 		assert!(tracker.finality_lag.is_none());
 
 		// Inject a fork and relevant finalized block number
@@ -665,7 +665,7 @@ mod test_inject_block {
 		storage_write(CollectorPrefixType::RelevantFinalizedBlockNumber, second_hash, 40, &storage)
 			.await
 			.unwrap();
-		storage_write(CollectorPrefixType::Timestamp, second_hash, 1694095333, &storage)
+		storage_write(CollectorPrefixType::Timestamp, second_hash, 2, &storage)
 			.await
 			.unwrap();
 		tracker
@@ -677,7 +677,7 @@ mod test_inject_block {
 		let current = tracker.current_relay_block.unwrap();
 		assert_eq!(previous.hash, first_hash);
 		assert_eq!(current.hash, second_hash);
-		assert_eq!(tracker.last_non_fork_relay_block_ts, Some(1694095332));
+		assert_eq!(tracker.last_non_fork_relay_block_ts, Some(1));
 		assert_eq!(tracker.finality_lag, Some(2));
 	}
 }

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -27,13 +27,11 @@ use crate::{
 };
 use log::{error, info};
 use polkadot_introspector_essentials::{
-	api::subxt_wrapper::SubxtWrapperError,
 	collector::DisputeInfo,
 	metadata::polkadot_primitives::{AvailabilityBitfield, BackedCandidate, DisputeStatementSet, ValidatorIndex},
 	types::{BlockNumber, CoreOccupied, OnDemandOrder, Timestamp, H256},
 };
 use std::{default::Default, time::Duration};
-use subxt::error::{Error, MetadataError};
 
 /// A subxt based parachain candidate tracker.
 pub struct SubxtTracker {
@@ -118,7 +116,7 @@ impl SubxtTracker {
 			self.set_forks(block_hash, block_number);
 
 			self.set_current_candidate(backed_candidates, bitfields.len(), block_number);
-			self.set_core_assignment(block_hash, rpc, storage).await?;
+			self.set_core_assignment(block_hash, storage).await?;
 			self.set_disputes(&disputes[..], storage).await;
 
 			self.set_hrmp_channels(block_hash, rpc).await?;
@@ -253,25 +251,9 @@ impl SubxtTracker {
 		}
 	}
 
-	async fn set_core_assignment(
-		&mut self,
-		block_hash: H256,
-		rpc: &mut impl TrackerRpc,
-		storage: &TrackerStorage,
-	) -> color_eyre::Result<()> {
-		// After adding On-demand Parachains, `ParaScheduler.Scheduled` API call will be removed
-		let mut assignments = rpc.core_assignments_via_scheduled_paras(block_hash).await;
-		// `ParaScheduler,Scheduled` not found, try to fetch `ParaScheduler.ClaimQueue`
-		if let Err(SubxtWrapperError::SubxtError(Error::Metadata(MetadataError::StorageEntryNotFound(_)))) = assignments
-		{
-			assignments = rpc.core_assignments_via_claim_queue(block_hash).await;
-		}
-		if let Err(SubxtWrapperError::EmptyResponseFromDynamicStorage(reason)) = assignments {
-			info!("{}. Nothing to process", reason);
-			return Ok(())
-		}
-
-		if let Some((&core, scheduled_ids)) = assignments?.iter().find(|(_, ids)| ids.contains(&self.para_id)) {
+	async fn set_core_assignment(&mut self, block_hash: H256, storage: &TrackerStorage) -> color_eyre::Result<()> {
+		let assignments = storage.core_assignments(block_hash).await.expect("saved in the collector");
+		if let Some((&core, scheduled_ids)) = assignments.iter().find(|(_, ids)| ids.contains(&self.para_id)) {
 			self.current_candidate.assigned_core = Some(core);
 			self.current_candidate.core_occupied = matches!(
 				storage.occupied_cores(block_hash).await.expect("saved in the collector")[core as usize],
@@ -609,6 +591,8 @@ mod test_maybe_reset_state {
 
 #[cfg(test)]
 mod test_inject_block {
+	use std::collections::BTreeMap;
+
 	use super::*;
 	use crate::{
 		test_utils::{create_inherent_data, create_storage, storage_write},
@@ -650,13 +634,13 @@ mod test_inject_block {
 		let mut tracker = SubxtTracker::new(100);
 		let tracker_storage = TrackerStorage::new(100, storage.clone());
 		let mut mock_rpc = MockTrackerRpc::new();
-		mock_rpc
-			.expect_core_assignments_via_scheduled_paras()
-			.returning(|_| Ok(Default::default()));
 		mock_rpc.expect_inbound_hrmp_channels().returning(|_| Ok(Default::default()));
 		mock_rpc.expect_outbound_hrmp_channels().returning(|_| Ok(Default::default()));
 
 		// Inject a block
+		storage_write(CollectorPrefixType::CoreAssignments, first_hash, BTreeMap::<u32, Vec<u32>>::default(), &storage)
+			.await
+			.unwrap();
 		storage_write(CollectorPrefixType::InherentData, first_hash, create_inherent_data(100), &storage)
 			.await
 			.unwrap();

--- a/parachain-tracer/src/tracker_rpc.rs
+++ b/parachain-tracer/src/tracker_rpc.rs
@@ -18,7 +18,6 @@ use async_trait::async_trait;
 use mockall::automock;
 use polkadot_introspector_essentials::{
 	api::subxt_wrapper::{RequestExecutor, SubxtHrmpChannel, SubxtWrapperError},
-	metadata::polkadot_primitives::ValidatorIndex,
 	types::H256,
 };
 use std::collections::{BTreeMap, HashMap};
@@ -42,10 +41,6 @@ pub trait TrackerRpc {
 		&mut self,
 		block_hash: H256,
 	) -> color_eyre::Result<HashMap<u32, Vec<u32>>, SubxtWrapperError>;
-	async fn backing_groups(
-		&mut self,
-		block_hash: H256,
-	) -> color_eyre::Result<Vec<Vec<ValidatorIndex>>, SubxtWrapperError>;
 }
 
 pub struct ParachainTrackerRpc {
@@ -113,14 +108,6 @@ impl TrackerRpc for ParachainTrackerRpc {
 			})
 			.collect())
 	}
-
-	// TODO: move to the storage
-	async fn backing_groups(
-		&mut self,
-		block_hash: H256,
-	) -> color_eyre::Result<Vec<Vec<ValidatorIndex>>, SubxtWrapperError> {
-		self.executor.get_backing_groups(self.node.as_str(), block_hash).await
-	}
 }
 
 #[cfg(test)]
@@ -179,14 +166,5 @@ mod tests {
 				assert_eq!(reason, "ClaimQueue"),
 			_ => assert!(response.is_ok()),
 		};
-	}
-
-	#[tokio::test]
-	async fn test_fetches_backing_groups() {
-		let (mut rpc, block_hash) = setup_client().await;
-
-		let response = rpc.backing_groups(block_hash).await;
-
-		assert!(!response.unwrap().is_empty());
 	}
 }

--- a/parachain-tracer/src/tracker_rpc.rs
+++ b/parachain-tracer/src/tracker_rpc.rs
@@ -46,7 +46,6 @@ pub trait TrackerRpc {
 		&mut self,
 		block_hash: H256,
 	) -> color_eyre::Result<Vec<Vec<ValidatorIndex>>, SubxtWrapperError>;
-	async fn block_timestamp(&mut self, block_hash: H256) -> color_eyre::Result<u64, SubxtWrapperError>;
 	async fn occupied_cores(&mut self, block_hash: H256) -> color_eyre::Result<Vec<CoreOccupied>, SubxtWrapperError>;
 }
 
@@ -85,6 +84,7 @@ impl TrackerRpc for ParachainTrackerRpc {
 			.await
 	}
 
+	// TODO: move to the storage
 	async fn core_assignments_via_scheduled_paras(
 		&mut self,
 		block_hash: H256,
@@ -97,6 +97,7 @@ impl TrackerRpc for ParachainTrackerRpc {
 			.collect::<HashMap<_, _>>())
 	}
 
+	// TODO: move to the storage
 	async fn core_assignments_via_claim_queue(
 		&mut self,
 		block_hash: H256,
@@ -114,6 +115,7 @@ impl TrackerRpc for ParachainTrackerRpc {
 			.collect())
 	}
 
+	// TODO: move to the storage
 	async fn backing_groups(
 		&mut self,
 		block_hash: H256,
@@ -121,10 +123,7 @@ impl TrackerRpc for ParachainTrackerRpc {
 		self.executor.get_backing_groups(self.node.as_str(), block_hash).await
 	}
 
-	async fn block_timestamp(&mut self, block_hash: H256) -> color_eyre::Result<u64, SubxtWrapperError> {
-		self.executor.get_block_timestamp(self.node.as_str(), block_hash).await
-	}
-
+	// TODO: move to the storage
 	async fn occupied_cores(&mut self, block_hash: H256) -> color_eyre::Result<Vec<CoreOccupied>, SubxtWrapperError> {
 		self.executor.get_occupied_cores(self.node.as_str(), block_hash).await
 	}
@@ -195,15 +194,6 @@ mod tests {
 		let response = rpc.backing_groups(block_hash).await;
 
 		assert!(!response.unwrap().is_empty());
-	}
-
-	#[tokio::test]
-	async fn test_fetches_block_timestamp() {
-		let (mut rpc, block_hash) = setup_client().await;
-
-		let response = rpc.block_timestamp(block_hash).await;
-
-		assert!(response.unwrap() > 0);
 	}
 
 	#[tokio::test]

--- a/parachain-tracer/src/tracker_rpc.rs
+++ b/parachain-tracer/src/tracker_rpc.rs
@@ -19,7 +19,7 @@ use mockall::automock;
 use polkadot_introspector_essentials::{
 	api::subxt_wrapper::{RequestExecutor, SubxtHrmpChannel, SubxtWrapperError},
 	metadata::polkadot_primitives::ValidatorIndex,
-	types::{CoreOccupied, H256},
+	types::H256,
 };
 use std::collections::{BTreeMap, HashMap};
 
@@ -46,7 +46,6 @@ pub trait TrackerRpc {
 		&mut self,
 		block_hash: H256,
 	) -> color_eyre::Result<Vec<Vec<ValidatorIndex>>, SubxtWrapperError>;
-	async fn occupied_cores(&mut self, block_hash: H256) -> color_eyre::Result<Vec<CoreOccupied>, SubxtWrapperError>;
 }
 
 pub struct ParachainTrackerRpc {
@@ -122,11 +121,6 @@ impl TrackerRpc for ParachainTrackerRpc {
 	) -> color_eyre::Result<Vec<Vec<ValidatorIndex>>, SubxtWrapperError> {
 		self.executor.get_backing_groups(self.node.as_str(), block_hash).await
 	}
-
-	// TODO: move to the storage
-	async fn occupied_cores(&mut self, block_hash: H256) -> color_eyre::Result<Vec<CoreOccupied>, SubxtWrapperError> {
-		self.executor.get_occupied_cores(self.node.as_str(), block_hash).await
-	}
 }
 
 #[cfg(test)]
@@ -192,15 +186,6 @@ mod tests {
 		let (mut rpc, block_hash) = setup_client().await;
 
 		let response = rpc.backing_groups(block_hash).await;
-
-		assert!(!response.unwrap().is_empty());
-	}
-
-	#[tokio::test]
-	async fn test_fetches_occupied_cores() {
-		let (mut rpc, block_hash) = setup_client().await;
-
-		let response = rpc.occupied_cores(block_hash).await;
 
 		assert!(!response.unwrap().is_empty());
 	}

--- a/parachain-tracer/src/tracker_rpc.rs
+++ b/parachain-tracer/src/tracker_rpc.rs
@@ -20,7 +20,7 @@ use polkadot_introspector_essentials::{
 	api::subxt_wrapper::{RequestExecutor, SubxtHrmpChannel, SubxtWrapperError},
 	types::H256,
 };
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 #[automock]
 #[async_trait]
@@ -33,14 +33,6 @@ pub trait TrackerRpc {
 		&mut self,
 		block_hash: H256,
 	) -> color_eyre::Result<BTreeMap<u32, SubxtHrmpChannel>, SubxtWrapperError>;
-	async fn core_assignments_via_scheduled_paras(
-		&mut self,
-		block_hash: H256,
-	) -> color_eyre::Result<HashMap<u32, Vec<u32>>, SubxtWrapperError>;
-	async fn core_assignments_via_claim_queue(
-		&mut self,
-		block_hash: H256,
-	) -> color_eyre::Result<HashMap<u32, Vec<u32>>, SubxtWrapperError>;
 }
 
 pub struct ParachainTrackerRpc {
@@ -77,44 +69,12 @@ impl TrackerRpc for ParachainTrackerRpc {
 			.get_outbound_hrmp_channels(self.node.as_str(), block_hash, self.para_id)
 			.await
 	}
-
-	// TODO: move to the storage
-	async fn core_assignments_via_scheduled_paras(
-		&mut self,
-		block_hash: H256,
-	) -> color_eyre::Result<HashMap<u32, Vec<u32>>, SubxtWrapperError> {
-		let core_assignments = self.executor.get_scheduled_paras(self.node.as_str(), block_hash).await?;
-
-		Ok(core_assignments
-			.iter()
-			.map(|v| (v.core.0, vec![v.para_id.0]))
-			.collect::<HashMap<_, _>>())
-	}
-
-	// TODO: move to the storage
-	async fn core_assignments_via_claim_queue(
-		&mut self,
-		block_hash: H256,
-	) -> color_eyre::Result<HashMap<u32, Vec<u32>>, SubxtWrapperError> {
-		let assignments = self.executor.get_claim_queue(self.node.as_str(), block_hash).await?;
-		Ok(assignments
-			.iter()
-			.map(|(core, queue)| {
-				let ids = queue
-					.iter()
-					.filter_map(|v| v.as_ref().map(|v| v.assignment.para_id))
-					.collect::<Vec<_>>();
-				(*core, ids)
-			})
-			.collect())
-	}
 }
 
 #[cfg(test)]
 mod tests {
 	use super::*;
 	use crate::test_utils::{create_api, rpc_node_url};
-	use subxt::error::{Error, MetadataError};
 
 	async fn setup_client() -> (ParachainTrackerRpc, H256) {
 		let api = create_api();
@@ -140,31 +100,5 @@ mod tests {
 		let response = rpc.outbound_hrmp_channels(block_hash).await;
 
 		assert!(response.is_ok());
-	}
-
-	#[tokio::test]
-	async fn test_fetches_core_assignments_via_scheduled_paras() {
-		let (mut rpc, block_hash) = setup_client().await;
-
-		let response = rpc.core_assignments_via_scheduled_paras(block_hash).await;
-
-		match response {
-			Err(SubxtWrapperError::SubxtError(Error::Metadata(MetadataError::StorageEntryNotFound(reason)))) =>
-				assert_eq!(reason, "Scheduled"),
-			_ => assert!(response.is_ok()),
-		};
-	}
-
-	#[tokio::test]
-	async fn test_fetches_core_assignments_via_claim_queue() {
-		let (mut rpc, block_hash) = setup_client().await;
-
-		let response = rpc.core_assignments_via_claim_queue(block_hash).await;
-
-		match response {
-			Err(SubxtWrapperError::SubxtError(Error::Metadata(MetadataError::StorageEntryNotFound(reason)))) =>
-				assert_eq!(reason, "ClaimQueue"),
-			_ => assert!(response.is_ok()),
-		};
 	}
 }

--- a/parachain-tracer/src/tracker_storage.rs
+++ b/parachain-tracer/src/tracker_storage.rs
@@ -17,7 +17,7 @@
 use polkadot_introspector_essentials::{
 	api::{storage::RequestExecutor, subxt_wrapper::InherentData},
 	collector::{candidate_record::CandidateRecord, CollectorPrefixType, DisputeInfo},
-	types::{AccountId32, OnDemandOrder, H256},
+	types::{AccountId32, OnDemandOrder, Timestamp, H256},
 };
 use subxt::config::{substrate::BlakeTwo256, Hasher};
 
@@ -71,9 +71,16 @@ impl TrackerStorage {
 			.map(|v| v.into_inner().unwrap())
 	}
 
-	pub async fn candidate(&self, candidate_hash: H256) -> Option<CandidateRecord> {
+	pub async fn candidate(&self, block_hash: H256) -> Option<CandidateRecord> {
 		self.storage
-			.storage_read_prefixed(CollectorPrefixType::Candidate(self.para_id), candidate_hash)
+			.storage_read_prefixed(CollectorPrefixType::Candidate(self.para_id), block_hash)
+			.await
+			.map(|v| v.into_inner().unwrap())
+	}
+
+	pub async fn block_timestamp(&self, block_hash: H256) -> Option<Timestamp> {
+		self.storage
+			.storage_read_prefixed(CollectorPrefixType::Timestamp, block_hash)
 			.await
 			.map(|v| v.into_inner().unwrap())
 	}

--- a/parachain-tracer/src/tracker_storage.rs
+++ b/parachain-tracer/src/tracker_storage.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::BTreeMap;
+
 use polkadot_introspector_essentials::{
 	api::{storage::RequestExecutor, subxt_wrapper::InherentData},
 	collector::{candidate_record::CandidateRecord, CollectorPrefixType, DisputeInfo},
@@ -96,6 +98,13 @@ impl TrackerStorage {
 	pub async fn backing_groups(&self, block_hash: H256) -> Option<Vec<Vec<ValidatorIndex>>> {
 		self.storage
 			.storage_read_prefixed(CollectorPrefixType::BackingGroups, block_hash)
+			.await
+			.map(|v| v.into_inner().unwrap())
+	}
+
+	pub async fn core_assignments(&self, block_hash: H256) -> Option<BTreeMap<u32, Vec<u32>>> {
+		self.storage
+			.storage_read_prefixed(CollectorPrefixType::CoreAssignments, block_hash)
 			.await
 			.map(|v| v.into_inner().unwrap())
 	}

--- a/parachain-tracer/src/tracker_storage.rs
+++ b/parachain-tracer/src/tracker_storage.rs
@@ -17,6 +17,7 @@
 use polkadot_introspector_essentials::{
 	api::{storage::RequestExecutor, subxt_wrapper::InherentData},
 	collector::{candidate_record::CandidateRecord, CollectorPrefixType, DisputeInfo},
+	metadata::polkadot_primitives::ValidatorIndex,
 	types::{AccountId32, CoreOccupied, OnDemandOrder, Timestamp, H256},
 };
 use subxt::config::{substrate::BlakeTwo256, Hasher};
@@ -88,6 +89,13 @@ impl TrackerStorage {
 	pub async fn occupied_cores(&self, block_hash: H256) -> Option<Vec<CoreOccupied>> {
 		self.storage
 			.storage_read_prefixed(CollectorPrefixType::OccupiedCores, block_hash)
+			.await
+			.map(|v| v.into_inner().unwrap())
+	}
+
+	pub async fn backing_groups(&self, block_hash: H256) -> Option<Vec<Vec<ValidatorIndex>>> {
+		self.storage
+			.storage_read_prefixed(CollectorPrefixType::BackingGroups, block_hash)
 			.await
 			.map(|v| v.into_inner().unwrap())
 	}

--- a/parachain-tracer/src/tracker_storage.rs
+++ b/parachain-tracer/src/tracker_storage.rs
@@ -14,14 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::BTreeMap;
-
 use polkadot_introspector_essentials::{
 	api::{storage::RequestExecutor, subxt_wrapper::InherentData},
 	collector::{candidate_record::CandidateRecord, CollectorPrefixType, DisputeInfo},
 	metadata::polkadot_primitives::ValidatorIndex,
 	types::{AccountId32, CoreOccupied, OnDemandOrder, Timestamp, H256},
 };
+use std::collections::BTreeMap;
 use subxt::config::{substrate::BlakeTwo256, Hasher};
 
 pub struct TrackerStorage {

--- a/parachain-tracer/src/tracker_storage.rs
+++ b/parachain-tracer/src/tracker_storage.rs
@@ -35,6 +35,7 @@ impl TrackerStorage {
 		Self { para_id, storage }
 	}
 
+	/// Reads validators account keys for the given session index
 	pub async fn session_keys(&self, session_index: u32) -> Option<Vec<AccountId32>> {
 		self.storage
 			.storage_read_prefixed(
@@ -45,6 +46,7 @@ impl TrackerStorage {
 			.map(|v| v.into_inner().unwrap())
 	}
 
+	/// Reads inherent data of a relay block by its block hash
 	pub async fn inherent_data(&self, block_hash: H256) -> Option<InherentData> {
 		self.storage
 			.storage_read_prefixed(CollectorPrefixType::InherentData, block_hash)
@@ -52,6 +54,7 @@ impl TrackerStorage {
 			.map(|v| v.into_inner().unwrap())
 	}
 
+	/// Reads on-demand order information by para id and block hash when it was placed
 	pub async fn on_demand_order(&self, block_hash: H256) -> Option<OnDemandOrder> {
 		self.storage
 			.storage_read_prefixed(CollectorPrefixType::OnDemandOrder(self.para_id), block_hash)
@@ -59,6 +62,7 @@ impl TrackerStorage {
 			.map(|v| v.into_inner().unwrap())
 	}
 
+	/// Reads the last finalized block number at the moment, when the given block has appeared
 	pub async fn relevant_finalized_block_number(&self, block_hash: H256) -> Option<u32> {
 		self.storage
 			.storage_read_prefixed(CollectorPrefixType::RelevantFinalizedBlockNumber, block_hash)
@@ -66,6 +70,7 @@ impl TrackerStorage {
 			.map(|v| v.into_inner().unwrap())
 	}
 
+	/// Read the dispute info for the given block by parachain id
 	pub async fn dispute(&self, block_hash: H256) -> Option<DisputeInfo> {
 		self.storage
 			.storage_read_prefixed(CollectorPrefixType::Dispute(self.para_id), block_hash)
@@ -73,13 +78,15 @@ impl TrackerStorage {
 			.map(|v| v.into_inner().unwrap())
 	}
 
-	pub async fn candidate(&self, block_hash: H256) -> Option<CandidateRecord> {
+	/// Read the candidate info for the given parablock by parachain id
+	pub async fn candidate(&self, candidate_hash: H256) -> Option<CandidateRecord> {
 		self.storage
-			.storage_read_prefixed(CollectorPrefixType::Candidate(self.para_id), block_hash)
+			.storage_read_prefixed(CollectorPrefixType::Candidate(self.para_id), candidate_hash)
 			.await
 			.map(|v| v.into_inner().unwrap())
 	}
 
+	/// Read the timestamp for the given relay block
 	pub async fn block_timestamp(&self, block_hash: H256) -> Option<Timestamp> {
 		self.storage
 			.storage_read_prefixed(CollectorPrefixType::Timestamp, block_hash)
@@ -87,6 +94,7 @@ impl TrackerStorage {
 			.map(|v| v.into_inner().unwrap())
 	}
 
+	/// Read the occupied cores for the given relay block
 	pub async fn occupied_cores(&self, block_hash: H256) -> Option<Vec<CoreOccupied>> {
 		self.storage
 			.storage_read_prefixed(CollectorPrefixType::OccupiedCores, block_hash)
@@ -94,6 +102,7 @@ impl TrackerStorage {
 			.map(|v| v.into_inner().unwrap())
 	}
 
+	/// Read the backing groups for the given relay block
 	pub async fn backing_groups(&self, block_hash: H256) -> Option<Vec<Vec<ValidatorIndex>>> {
 		self.storage
 			.storage_read_prefixed(CollectorPrefixType::BackingGroups, block_hash)
@@ -101,6 +110,7 @@ impl TrackerStorage {
 			.map(|v| v.into_inner().unwrap())
 	}
 
+	/// Read the core assignments for the given relay block
 	pub async fn core_assignments(&self, block_hash: H256) -> Option<BTreeMap<u32, Vec<u32>>> {
 		self.storage
 			.storage_read_prefixed(CollectorPrefixType::CoreAssignments, block_hash)

--- a/parachain-tracer/src/tracker_storage.rs
+++ b/parachain-tracer/src/tracker_storage.rs
@@ -17,7 +17,7 @@
 use polkadot_introspector_essentials::{
 	api::{storage::RequestExecutor, subxt_wrapper::InherentData},
 	collector::{candidate_record::CandidateRecord, CollectorPrefixType, DisputeInfo},
-	types::{AccountId32, OnDemandOrder, Timestamp, H256},
+	types::{AccountId32, CoreOccupied, OnDemandOrder, Timestamp, H256},
 };
 use subxt::config::{substrate::BlakeTwo256, Hasher};
 
@@ -81,6 +81,13 @@ impl TrackerStorage {
 	pub async fn block_timestamp(&self, block_hash: H256) -> Option<Timestamp> {
 		self.storage
 			.storage_read_prefixed(CollectorPrefixType::Timestamp, block_hash)
+			.await
+			.map(|v| v.into_inner().unwrap())
+	}
+
+	pub async fn occupied_cores(&self, block_hash: H256) -> Option<Vec<CoreOccupied>> {
+		self.storage
+			.storage_read_prefixed(CollectorPrefixType::OccupiedCores, block_hash)
 			.await
 			.map(|v| v.into_inner().unwrap())
 	}


### PR DESCRIPTION

### Done
1. Removed unused RPC queries, see `essentials/src/api/subxt_wrapper.rs`.
1. Common for all parachains queries cached in the collector (ts, occupied_cores, backing_groups, core_assignments).

### Results

Tested on Polkadot, in historical mode, between blocks 17762300-17762310.

#### Number of RPC requests
|  | before | after |
|--------|--------|--------|
| For 2 paras | 192 | 164 |
| For all (38) paras | 1571 | 722 |

With a large number of parachains on a given interval, the number of queries decreased by about half. 
