### PR TITLE
Add light client support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,6 +1007,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d2f3407d9a573d666de4b5bdf10569d73ca9478087346697dcbae6244bfbcd"
+
+[[package]]
 name = "ed25519-zebra"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2453,6 +2459,7 @@ dependencies = [
  "async-trait",
  "clap",
  "color-eyre",
+ "dyn-clone",
  "env_logger",
  "futures",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3667,6 +3667,7 @@ dependencies = [
  "subxt-macro",
  "subxt-metadata",
  "thiserror",
+ "tokio-stream",
  "tracing",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ parity-scale-codec = { version = "3.6.5", default-features = false, features = [
 color-eyre = "0.6.2"
 colored = "2.0.4"
 crossterm = "0.26.1"
+dyn-clone = "1.0.14"
 env_logger = "0.10.1"
 erased-serde = "0.3.31"
 futures = "0.3.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = "1.0.108"
 serde_urlencoded = "0.7.1"
 snap = "1.1.0"
 strum = { version = "0.25.0", features = ["derive"] }
-subxt = { default-features = false, features = ["jsonrpsee", "native"], version = "0.32.1" }
+subxt = { default-features = false, features = ["jsonrpsee", "native", "unstable-light-client"], version = "0.32.1" }
 base64 = "0.21.5"
 thiserror = "1.0.50"
 time = { version = "0.3.30", features = ["formatting"] }

--- a/block-time/src/main.rs
+++ b/block-time/src/main.rs
@@ -23,7 +23,7 @@ use crossterm::{
 };
 use log::{debug, info, warn};
 use polkadot_introspector_essentials::{
-	api::subxt_wrapper::RequestExecutor,
+	api::subxt_wrapper::{ApiClientMode, RequestExecutor},
 	chain_head_subscription::ChainHeadSubscription,
 	chain_subscription::ChainSubscriptionEvent,
 	constants::MAX_MSG_QUEUE_SIZE,
@@ -100,7 +100,7 @@ struct BlockTimeMonitor {
 
 impl BlockTimeMonitor {
 	pub fn new(opts: BlockTimeOptions) -> color_eyre::Result<Self> {
-		let executor = RequestExecutor::new(opts.retry.clone());
+		let executor = RequestExecutor::new(ApiClientMode::Online, opts.retry.clone());
 		let endpoints = opts.nodes.clone();
 		let active_endpoints = endpoints.len();
 
@@ -377,7 +377,7 @@ async fn main() -> color_eyre::Result<()> {
 	let shutdown_tx = init::init_shutdown();
 	let mut futures = vec![];
 
-	let mut sub = ChainHeadSubscription::new(opts.nodes.clone(), opts.retry.clone());
+	let mut sub = ChainHeadSubscription::new(opts.nodes.clone(), ApiClientMode::Online, opts.retry.clone());
 	let consumer_init = sub.create_consumer();
 
 	futures.extend(monitor.run(consumer_init).await?);

--- a/block-time/src/main.rs
+++ b/block-time/src/main.rs
@@ -100,7 +100,7 @@ struct BlockTimeMonitor {
 
 impl BlockTimeMonitor {
 	pub fn new(opts: BlockTimeOptions) -> color_eyre::Result<Self> {
-		let executor = RequestExecutor::new(ApiClientMode::Online, opts.retry.clone());
+		let executor = RequestExecutor::new(ApiClientMode::RPC, opts.retry.clone());
 		let endpoints = opts.nodes.clone();
 		let active_endpoints = endpoints.len();
 
@@ -377,7 +377,7 @@ async fn main() -> color_eyre::Result<()> {
 	let shutdown_tx = init::init_shutdown();
 	let mut futures = vec![];
 
-	let mut sub = ChainHeadSubscription::new(opts.nodes.clone(), ApiClientMode::Online, opts.retry.clone());
+	let mut sub = ChainHeadSubscription::new(opts.nodes.clone(), ApiClientMode::RPC, opts.retry.clone());
 	let consumer_init = sub.create_consumer();
 
 	futures.extend(monitor.run(consumer_init).await?);

--- a/essentials/Cargo.toml
+++ b/essentials/Cargo.toml
@@ -12,6 +12,7 @@ async-trait = { workspace = true }
 clap = { workspace = true }
 parity-scale-codec = { workspace = true }
 color-eyre = { workspace = true }
+dyn-clone = { workspace = true }
 env_logger = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }

--- a/essentials/src/api/api_client.rs
+++ b/essentials/src/api/api_client.rs
@@ -15,47 +15,55 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-use crate::types::{BlockNumber, Header, H256};
+use crate::{
+	metadata::polkadot,
+	types::{AccountId32, BlockNumber, Header, InherentData, SessionKeys, SubxtHrmpChannel, Timestamp, H256},
+};
 use dyn_clone::DynClone;
+use std::collections::BTreeMap;
 use subxt::{
 	backend::{
 		legacy::{rpc_methods::NumberOrHex, LegacyRpcMethods},
 		rpc::RpcClient,
 		StreamOf,
 	},
-	blocks::{BlockRef, BlocksClient},
+	blocks::{Block, BlockRef, BlocksClient},
 	client::{LightClient, OnlineClientT},
-	events::EventsClient,
+	dynamic::Value,
+	events::{Events, EventsClient},
 	storage::StorageClient,
-	Config, OnlineClient, PolkadotConfig,
+	OnlineClient, PolkadotConfig,
 };
 
-#[derive(Clone)]
-pub struct ApiClient {
-	client: OnlineClient<PolkadotConfig>,
-	legacy_rpc_methods: LegacyRpcMethods<PolkadotConfig>,
-}
-
 pub type HeaderStream = StreamOf<Result<(Header, BlockRef<H256>), subxt::Error>>;
-pub type MyHeaderStream<C> = StreamOf<Result<(<C as Config>::Header, BlockRef<<C as Config>::Hash>), subxt::Error>>;
-
-pub async fn build_api_client(url: &str) -> Result<ApiClient, String> {
-	let rpc_client = RpcClient::from_url(url)
-		.await
-		.map_err(|e| format!("Cannot construct RPC client: {e}"))?;
-	let client = OnlineClient::from_rpc_client(rpc_client.clone())
-		.await
-		.map_err(|e| format!("Cannot construct OnlineClient from rpc client: {e}"))?;
-	let legacy_rpc_methods = LegacyRpcMethods::<PolkadotConfig>::new(rpc_client);
-
-	Ok(ApiClient { client, legacy_rpc_methods })
-}
 
 #[async_trait::async_trait]
 pub trait ApiClientT: DynClone + Send + Sync {
-	fn storage(&self) -> StorageClient<PolkadotConfig, OnlineClient<PolkadotConfig>>;
-	fn blocks(&self) -> BlocksClient<PolkadotConfig, OnlineClient<PolkadotConfig>>;
-	fn events(&self) -> EventsClient<PolkadotConfig, OnlineClient<PolkadotConfig>>;
+	async fn get_head(&self, maybe_hash: Option<H256>) -> Result<Header, subxt::Error>;
+	async fn get_block_number(&self, maybe_hash: Option<H256>) -> Result<BlockNumber, subxt::Error>;
+	async fn get_block_ts(&self, hash: H256) -> Result<Option<Timestamp>, subxt::Error>;
+	async fn get_events(&self, hash: H256) -> Result<Events<PolkadotConfig>, subxt::Error>;
+	async fn get_session_index(&self, hash: H256) -> Result<Option<u32>, subxt::Error>;
+	async fn get_session_account_keys(&self, session_index: u32) -> Result<Option<Vec<AccountId32>>, subxt::Error>;
+	async fn get_session_next_keys(&self, account: &AccountId32) -> Result<Option<SessionKeys>, subxt::Error>;
+	async fn get_inbound_hrmp_channels(
+		&self,
+		block_hash: H256,
+		para_id: u32,
+	) -> Result<BTreeMap<u32, SubxtHrmpChannel>, subxt::Error>;
+	async fn get_outbound_hrmp_channels(
+		&self,
+		block_hash: H256,
+		para_id: u32,
+	) -> Result<BTreeMap<u32, SubxtHrmpChannel>, subxt::Error>;
+	async fn fetch_dynamic_storage(
+		&self,
+		maybe_hash: Option<H256>,
+		pallet_name: &str,
+		entry_name: &str,
+	) -> Result<Option<Value<u32>>, subxt::Error>;
+	async fn extract_parainherent(&self, maybe_hash: Option<H256>) -> Result<InherentData, subxt::Error>;
+	// We need it only for the historical mode to convert block numbers into their hashes
 	async fn legacy_get_block_hash(
 		&self,
 		maybe_block_number: Option<BlockNumber>,
@@ -64,21 +72,154 @@ pub trait ApiClientT: DynClone + Send + Sync {
 	async fn stream_finalized_block_headers(&self) -> Result<HeaderStream, subxt::Error>;
 }
 
-#[async_trait::async_trait]
-impl ApiClientT for ApiClient {
-	fn storage(&self) -> StorageClient<PolkadotConfig, OnlineClient<PolkadotConfig>> {
+#[derive(Clone)]
+pub struct ApiClient<T>
+where
+	T: OnlineClientT<PolkadotConfig>,
+{
+	client: T,
+	legacy_rpc_methods: LegacyRpcMethods<PolkadotConfig>,
+}
+
+impl<T: OnlineClientT<PolkadotConfig>> ApiClient<T> {
+	fn storage(&self) -> StorageClient<PolkadotConfig, T> {
 		self.client.storage()
 	}
 
-	fn blocks(&self) -> BlocksClient<PolkadotConfig, OnlineClient<PolkadotConfig>> {
+	fn blocks(&self) -> BlocksClient<PolkadotConfig, T> {
 		self.client.blocks()
 	}
 
-	fn events(&self) -> EventsClient<PolkadotConfig, OnlineClient<PolkadotConfig>> {
+	fn events(&self) -> EventsClient<PolkadotConfig, T> {
 		self.client.events()
 	}
 
-	// We need it only for the historical mode to convert block numbers into their hashes
+	async fn block_at(&self, maybe_hash: Option<H256>) -> Result<Block<PolkadotConfig, T>, subxt::Error> {
+		match maybe_hash {
+			Some(hash) => self.blocks().at(hash).await,
+			None => self.blocks().at_latest().await,
+		}
+	}
+}
+
+#[async_trait::async_trait]
+impl<T: OnlineClientT<PolkadotConfig>> ApiClientT for ApiClient<T> {
+	async fn get_head(&self, maybe_hash: Option<H256>) -> Result<Header, subxt::Error> {
+		Ok(self.block_at(maybe_hash).await?.header().clone())
+	}
+
+	async fn get_block_number(&self, maybe_hash: Option<H256>) -> Result<BlockNumber, subxt::Error> {
+		Ok(self.block_at(maybe_hash).await?.number())
+	}
+
+	async fn get_block_ts(&self, hash: H256) -> Result<Option<Timestamp>, subxt::Error> {
+		let timestamp = polkadot::storage().timestamp().now();
+		self.storage().at(hash).fetch(&timestamp).await
+	}
+
+	async fn get_events(&self, hash: H256) -> Result<Events<PolkadotConfig>, subxt::Error> {
+		self.events().at(hash).await
+	}
+
+	async fn get_session_index(&self, hash: H256) -> Result<Option<u32>, subxt::Error> {
+		let addr = polkadot::storage().session().current_index();
+		self.storage().at(hash).fetch(&addr).await
+	}
+
+	async fn get_session_account_keys(&self, session_index: u32) -> Result<Option<Vec<AccountId32>>, subxt::Error> {
+		let addr = polkadot::storage().para_session_info().account_keys(session_index);
+		self.storage().at_latest().await?.fetch(&addr).await
+	}
+
+	async fn get_session_next_keys(&self, account: &AccountId32) -> Result<Option<SessionKeys>, subxt::Error> {
+		let addr = polkadot::storage().session().next_keys(account);
+		self.storage().at_latest().await?.fetch(&addr).await
+	}
+
+	async fn get_inbound_hrmp_channels(
+		&self,
+		block_hash: H256,
+		para_id: u32,
+	) -> Result<BTreeMap<u32, SubxtHrmpChannel>, subxt::Error> {
+		use polkadot::runtime_types::polkadot_parachain::primitives::{HrmpChannelId, Id};
+		let addr = polkadot::storage().hrmp().hrmp_ingress_channels_index(&Id(para_id));
+		let hrmp_channels = self.storage().at(block_hash).fetch(&addr).await?.unwrap_or_default();
+		let mut channels_configuration: BTreeMap<u32, SubxtHrmpChannel> = BTreeMap::new();
+		for peer_parachain_id in hrmp_channels.into_iter().map(|id| id.0) {
+			let id = HrmpChannelId { sender: Id(peer_parachain_id), recipient: Id(para_id) };
+			let addr = polkadot::storage().hrmp().hrmp_channels(&id);
+			self.storage()
+				.at(block_hash)
+				.fetch(&addr)
+				.await?
+				.map(|hrmp_channel_configuration| {
+					channels_configuration.insert(peer_parachain_id, hrmp_channel_configuration.into())
+				});
+		}
+		Ok(channels_configuration)
+	}
+
+	async fn get_outbound_hrmp_channels(
+		&self,
+		block_hash: H256,
+		para_id: u32,
+	) -> Result<BTreeMap<u32, SubxtHrmpChannel>, subxt::Error> {
+		use polkadot::runtime_types::polkadot_parachain::primitives::{HrmpChannelId, Id};
+
+		let addr = polkadot::storage().hrmp().hrmp_egress_channels_index(&Id(para_id));
+		let hrmp_channels = self.storage().at(block_hash).fetch(&addr).await?.unwrap_or_default();
+		let mut channels_configuration: BTreeMap<u32, SubxtHrmpChannel> = BTreeMap::new();
+		for peer_parachain_id in hrmp_channels.into_iter().map(|id| id.0) {
+			let id = HrmpChannelId { sender: Id(peer_parachain_id), recipient: Id(para_id) };
+			let addr = polkadot::storage().hrmp().hrmp_channels(&id);
+			self.storage()
+				.at(block_hash)
+				.fetch(&addr)
+				.await?
+				.map(|hrmp_channel_configuration| {
+					channels_configuration.insert(peer_parachain_id, hrmp_channel_configuration.into())
+				});
+		}
+		Ok(channels_configuration)
+	}
+
+	async fn fetch_dynamic_storage(
+		&self,
+		maybe_hash: Option<H256>,
+		pallet_name: &str,
+		entry_name: &str,
+	) -> Result<Option<Value<u32>>, subxt::Error> {
+		let storage = match maybe_hash {
+			Some(hash) => self.storage().at(hash),
+			None => self.storage().at_latest().await?,
+		};
+		match storage
+			.fetch(&subxt::dynamic::storage(pallet_name, entry_name, Vec::<u8>::new()))
+			.await?
+		{
+			Some(v) => Ok(Some(v.to_value()?)),
+			None => Ok(None),
+		}
+	}
+
+	async fn extract_parainherent(&self, maybe_hash: Option<H256>) -> Result<InherentData, subxt::Error> {
+		let block = self.block_at(maybe_hash).await?;
+		let ex = block
+			.extrinsics()
+			.await?
+			.iter()
+			.take(2)
+			.last()
+			.expect("`ParaInherent` data is always at index #1")
+			.expect("`ParaInherent` data must exist");
+		let enter = ex
+			.as_extrinsic::<polkadot::para_inherent::calls::types::Enter>()
+			.expect("Failed to decode `ParaInherent`")
+			.expect("`ParaInherent` must exist");
+
+		Ok(enter.data)
+	}
+
 	async fn legacy_get_block_hash(
 		&self,
 		maybe_block_number: Option<BlockNumber>,
@@ -96,76 +237,27 @@ impl ApiClientT for ApiClient {
 	}
 }
 
-#[derive(Clone)]
-pub struct MyApiClient<T = OnlineClient<PolkadotConfig>, C = PolkadotConfig>
-where
-	T: OnlineClientT<C>,
-	C: Config,
-{
-	client: T,
-	legacy_rpc_methods: LegacyRpcMethods<C>,
+pub async fn build_online_client(url: &str) -> Result<ApiClient<OnlineClient<PolkadotConfig>>, String> {
+	let rpc_client = RpcClient::from_url(url)
+		.await
+		.map_err(|e| format!("Cannot construct RPC client: {e}"))?;
+	let client = OnlineClient::from_rpc_client(rpc_client.clone())
+		.await
+		.map_err(|e| format!("Cannot construct OnlineClient from rpc client: {e}"))?;
+	let legacy_rpc_methods = LegacyRpcMethods::<PolkadotConfig>::new(rpc_client);
+
+	Ok(ApiClient { client, legacy_rpc_methods })
 }
 
-impl<T, C> MyApiClient<T, C>
-where
-	T: OnlineClientT<C>,
-	C: Config,
-{
-	pub fn storage(&self) -> StorageClient<C, T> {
-		self.client.storage()
-	}
+pub async fn build_light_client(url: &str) -> Result<ApiClient<LightClient<PolkadotConfig>>, String> {
+	let rpc_client = RpcClient::from_url(url)
+		.await
+		.map_err(|e| format!("Cannot construct RPC client: {e}"))?;
+	let client = LightClient::builder()
+		.build_from_url(url)
+		.await
+		.map_err(|e| format!("Cannot construct LightClient from url: {e}"))?;
+	let legacy_rpc_methods = LegacyRpcMethods::<PolkadotConfig>::new(rpc_client);
 
-	pub fn blocks(&self) -> BlocksClient<C, T> {
-		self.client.blocks()
-	}
-
-	pub fn events(&self) -> EventsClient<C, T> {
-		self.client.events()
-	}
-
-	// We need it only for the historical mode to convert block numbers into their hashes
-	pub async fn legacy_get_block_hash(
-		&self,
-		maybe_block_number: Option<BlockNumber>,
-	) -> Result<Option<<C>::Hash>, subxt::Error> {
-		let maybe_block_number = maybe_block_number.map(|v| NumberOrHex::Number(v.into()));
-		self.legacy_rpc_methods.chain_get_block_hash(maybe_block_number).await
-	}
-
-	pub async fn stream_best_block_headers(&self) -> Result<MyHeaderStream<C>, subxt::Error> {
-		self.client.backend().stream_best_block_headers().await
-	}
-
-	pub async fn stream_finalized_block_headers(&self) -> Result<MyHeaderStream<C>, subxt::Error> {
-		self.client.backend().stream_finalized_block_headers().await
-	}
-}
-
-impl MyApiClient<OnlineClient<PolkadotConfig>> {
-	pub async fn build(url: &str) -> Result<MyApiClient, String> {
-		let rpc_client = RpcClient::from_url(url)
-			.await
-			.map_err(|e| format!("Cannot construct RPC client: {e}"))?;
-		let client = OnlineClient::from_rpc_client(rpc_client.clone())
-			.await
-			.map_err(|e| format!("Cannot construct OnlineClient from rpc client: {e}"))?;
-		let legacy_rpc_methods = LegacyRpcMethods::<PolkadotConfig>::new(rpc_client);
-
-		Ok(MyApiClient { client, legacy_rpc_methods })
-	}
-}
-
-impl MyApiClient<LightClient<PolkadotConfig>> {
-	pub async fn build(url: &str) -> Result<MyApiClient<LightClient<PolkadotConfig>>, String> {
-		let rpc_client = RpcClient::from_url(url)
-			.await
-			.map_err(|e| format!("Cannot construct RPC client: {e}"))?;
-		let client = LightClient::builder()
-			.build_from_url(url)
-			.await
-			.map_err(|e| format!("Cannot construct LightClient from url: {e}"))?;
-		let legacy_rpc_methods = LegacyRpcMethods::<PolkadotConfig>::new(rpc_client);
-
-		Ok(MyApiClient { client, legacy_rpc_methods })
-	}
+	Ok(ApiClient { client, legacy_rpc_methods })
 }

--- a/essentials/src/api/api_client.rs
+++ b/essentials/src/api/api_client.rs
@@ -210,12 +210,12 @@ impl<T: OnlineClientT<PolkadotConfig>> ApiClientT for ApiClient<T> {
 			.iter()
 			.take(2)
 			.last()
-			.expect("`ParaInherent` data is always at index #1")
-			.expect("`ParaInherent` data must exist");
+			.ok_or_else(|| "`ParaInherent` data is always at index #1".to_string())?
+			.map_err(|_| "`ParaInherent` data must exist".to_string())?;
 		let enter = ex
 			.as_extrinsic::<polkadot::para_inherent::calls::types::Enter>()
-			.expect("Failed to decode `ParaInherent`")
-			.expect("`ParaInherent` must exist");
+			.map_err(|_| "Failed to decode `ParaInherent`".to_string())?
+			.ok_or_else(|| "`ParaInherent` must exist".to_string())?;
 
 		Ok(enter.data)
 	}

--- a/essentials/src/api/mod.rs
+++ b/essentials/src/api/mod.rs
@@ -112,7 +112,7 @@ mod tests {
 
 		let head = subxt.get_block_head(rpc_node_url(), None).await.unwrap().unwrap();
 		let timestamp = subxt.get_block_timestamp(rpc_node_url(), head.hash()).await.unwrap();
-		let _block = subxt.get_block(rpc_node_url(), Some(head.hash())).await.unwrap();
+		let _block = subxt.get_block_number(rpc_node_url(), Some(head.hash())).await.unwrap();
 		assert!(timestamp > 0);
 	}
 
@@ -124,7 +124,6 @@ mod tests {
 		subxt
 			.extract_parainherent_data(rpc_node_url(), None)
 			.await
-			.unwrap()
 			.expect("Inherent data must be present");
 	}
 

--- a/essentials/src/api/mod.rs
+++ b/essentials/src/api/mod.rs
@@ -106,7 +106,7 @@ mod tests {
 	async fn basic_storage_test() {
 		let api = ApiService::new_with_storage(
 			RecordsStorageConfig { max_blocks: 10 },
-			ApiClientMode::Online,
+			ApiClientMode::RPC,
 			RetryOptions::default(),
 		);
 		let storage = api.storage();
@@ -123,7 +123,7 @@ mod tests {
 	async fn basic_subxt_test() {
 		let api = ApiService::<H256>::new_with_storage(
 			RecordsStorageConfig { max_blocks: 10 },
-			ApiClientMode::Online,
+			ApiClientMode::RPC,
 			RetryOptions::default(),
 		);
 		let mut subxt = api.subxt();
@@ -138,7 +138,7 @@ mod tests {
 	async fn extract_parainherent_data() {
 		let api = ApiService::<H256>::new_with_storage(
 			RecordsStorageConfig { max_blocks: 1 },
-			ApiClientMode::Online,
+			ApiClientMode::RPC,
 			RetryOptions::default(),
 		);
 		let mut subxt = api.subxt();
@@ -153,7 +153,7 @@ mod tests {
 	async fn get_scheduled_paras() {
 		let api = ApiService::<H256>::new_with_storage(
 			RecordsStorageConfig { max_blocks: 1 },
-			ApiClientMode::Online,
+			ApiClientMode::RPC,
 			RetryOptions::default(),
 		);
 		let mut subxt = api.subxt();
@@ -168,7 +168,7 @@ mod tests {
 	async fn get_occupied_cores() {
 		let api = ApiService::<H256>::new_with_storage(
 			RecordsStorageConfig { max_blocks: 1 },
-			ApiClientMode::Online,
+			ApiClientMode::RPC,
 			RetryOptions::default(),
 		);
 		let mut subxt = api.subxt();
@@ -183,7 +183,7 @@ mod tests {
 	async fn get_backing_groups() {
 		let api = ApiService::<H256>::new_with_storage(
 			RecordsStorageConfig { max_blocks: 1 },
-			ApiClientMode::Online,
+			ApiClientMode::RPC,
 			RetryOptions::default(),
 		);
 		let mut subxt = api.subxt();

--- a/essentials/src/api/subxt_wrapper.rs
+++ b/essentials/src/api/subxt_wrapper.rs
@@ -421,7 +421,7 @@ impl RequestExecutor {
 #[derive(strum::Display, Debug, Clone, Copy, ValueEnum, Default)]
 pub enum ApiClientMode {
 	#[default]
-	Online,
+	RPC,
 	Light,
 }
 
@@ -431,7 +431,7 @@ async fn new_client_fn(url: &str, api_client_mode: ApiClientMode, retry: &RetryO
 
 	loop {
 		match api_client_mode {
-			ApiClientMode::Online => match build_online_client(url).await {
+			ApiClientMode::RPC => match build_online_client(url).await {
 				Ok(client) => return Some(Box::new(client)),
 				Err(err) => {
 					error!("[{}] Client error: {:?}", url, err);

--- a/essentials/src/chain_head_subscription.rs
+++ b/essentials/src/chain_head_subscription.rs
@@ -61,7 +61,13 @@ impl EventStream for ChainHeadSubscription {
 
 	async fn run(&self, shutdown_tx: &BroadcastSender<()>) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>> {
 		let futures = self.consumers.clone().into_iter().map(|update_channels| {
-			Self::run_per_consumer(update_channels, self.urls.clone(), shutdown_tx.clone(), self.api_client_mode, self.retry.clone())
+			Self::run_per_consumer(
+				update_channels,
+				self.urls.clone(),
+				shutdown_tx.clone(),
+				self.api_client_mode,
+				self.retry.clone(),
+			)
 		});
 
 		Ok(futures.flatten().collect::<Vec<_>>())

--- a/essentials/src/collector/mod.rs
+++ b/essentials/src/collector/mod.rs
@@ -19,7 +19,7 @@ mod ws;
 
 use crate::{
 	api::{
-		subxt_wrapper::{RequestExecutor, SubxtWrapperError},
+		subxt_wrapper::{ApiClientMode, RequestExecutor, SubxtWrapperError},
 		ApiService,
 	},
 	chain_events::{
@@ -204,9 +204,10 @@ pub struct Collector {
 }
 
 impl Collector {
-	pub fn new(endpoint: &str, opts: CollectorOptions, retry: RetryOptions) -> Self {
+	pub fn new(endpoint: &str, opts: CollectorOptions, api_client_mode: ApiClientMode, retry: RetryOptions) -> Self {
 		let api: CollectorStorageApi = ApiService::new_with_prefixed_storage(
 			RecordsStorageConfig { max_blocks: opts.max_blocks.unwrap_or(64) },
+			api_client_mode,
 			retry,
 		);
 		let ws_listener = if let Some(listen_addr) = opts.listen_addr {

--- a/essentials/src/collector/mod.rs
+++ b/essentials/src/collector/mod.rs
@@ -19,7 +19,7 @@ mod ws;
 
 use crate::{
 	api::{
-		subxt_wrapper::{InherentData, RequestExecutor, SubxtWrapperError},
+		subxt_wrapper::{RequestExecutor, SubxtWrapperError},
 		ApiService,
 	},
 	chain_events::{
@@ -28,7 +28,7 @@ use crate::{
 	chain_subscription::ChainSubscriptionEvent,
 	metadata::polkadot_primitives::DisputeStatement,
 	storage::{RecordTime, RecordsStorageConfig, StorageEntry},
-	types::{Header, OnDemandOrder, Timestamp, H256},
+	types::{Header, InherentData, OnDemandOrder, Timestamp, H256},
 	utils::RetryOptions,
 };
 use candidate_record::{CandidateDisputed, CandidateInclusionRecord, CandidateRecord, DisputeResult};
@@ -604,17 +604,12 @@ impl Collector {
 			.executor
 			.extract_parainherent_data(self.endpoint.as_str(), Some(block_hash))
 			.await?;
-
-		if let Some(inherent_data) = inherent_data {
-			self.storage_write_prefixed(
-				CollectorPrefixType::InherentData,
-				block_hash,
-				StorageEntry::new_onchain(RecordTime::with_ts(block_number, Duration::from_secs(ts)), inherent_data),
-			)
-			.await?;
-		} else {
-			warn!("cannot get inherent data for block number {} ({})", block_number, block_hash);
-		}
+		self.storage_write_prefixed(
+			CollectorPrefixType::InherentData,
+			block_hash,
+			StorageEntry::new_onchain(RecordTime::with_ts(block_number, Duration::from_secs(ts)), inherent_data),
+		)
+		.await?;
 
 		Ok(())
 	}

--- a/essentials/src/historical_subscription.rs
+++ b/essentials/src/historical_subscription.rs
@@ -103,8 +103,8 @@ impl HistoricalSubscription {
 		const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(1000);
 		let mut heartbeat_periodic = interval_at(tokio::time::Instant::now() + HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL);
 
-		let last_block_number = match executor.get_block(&url, None).await {
-			Ok(block) => block.number(),
+		let last_block_number = match executor.get_block_number(&url, None).await {
+			Ok(v) => v,
 			Err(_) => {
 				error!("Subscription to {} failed, last block not found", url);
 				return

--- a/essentials/src/types.rs
+++ b/essentials/src/types.rs
@@ -20,7 +20,7 @@ use crate::metadata::{
 		runtime_types as subxt_runtime_types,
 		runtime_types::{polkadot_parachain::primitives::Id, polkadot_runtime_parachains::scheduler::AssignmentKind},
 	},
-	polkadot_primitives::CoreIndex,
+	polkadot_primitives,
 };
 use parity_scale_codec::{Decode, Encode};
 use std::collections::{BTreeMap, VecDeque};
@@ -39,11 +39,47 @@ pub type SessionKeys = runtime::SessionKeys;
 pub type SubxtCall = runtime::RuntimeCall;
 pub type ClaimQueue = BTreeMap<u32, VecDeque<Option<ParasEntry>>>;
 
+/// The `InherentData` constructed with the subxt API.
+pub type InherentData = polkadot_primitives::InherentData<
+	subxt_runtime_types::sp_runtime::generic::header::Header<
+		::core::primitive::u32,
+		subxt_runtime_types::sp_runtime::traits::BlakeTwo256,
+	>,
+>;
+
+/// A wrapper over subxt HRMP channel configuration
+#[derive(Debug, Clone, Default)]
+pub struct SubxtHrmpChannel {
+	pub max_capacity: u32,
+	pub max_total_size: u32,
+	pub max_message_size: u32,
+	pub msg_count: u32,
+	pub total_size: u32,
+	pub mqc_head: Option<H256>,
+	pub sender_deposit: u128,
+	pub recipient_deposit: u128,
+}
+
+impl From<subxt_runtime_types::polkadot_runtime_parachains::hrmp::HrmpChannel> for SubxtHrmpChannel {
+	fn from(channel: subxt_runtime_types::polkadot_runtime_parachains::hrmp::HrmpChannel) -> Self {
+		SubxtHrmpChannel {
+			max_capacity: channel.max_capacity,
+			max_total_size: channel.max_total_size,
+			max_message_size: channel.max_message_size,
+			msg_count: channel.msg_count,
+			total_size: channel.total_size,
+			mqc_head: channel.mqc_head,
+			sender_deposit: channel.sender_deposit,
+			recipient_deposit: channel.recipient_deposit,
+		}
+	}
+}
+
 // TODO: Take it from runtime types v5
 /// How a free core is scheduled to be assigned.
 pub struct CoreAssignment {
 	/// The core that is assigned.
-	pub core: CoreIndex,
+	pub core: polkadot_primitives::CoreIndex,
 	/// The unique ID of the para that is assigned to the core.
 	pub para_id: Id,
 	/// The kind of the assignment.

--- a/parachain-tracer/src/main.rs
+++ b/parachain-tracer/src/main.rs
@@ -34,7 +34,7 @@ use futures::{future, stream::FuturesUnordered, StreamExt};
 use itertools::Itertools;
 use log::{error, info, warn};
 use polkadot_introspector_essentials::{
-	api::subxt_wrapper::RequestExecutor,
+	api::subxt_wrapper::{ApiClientMode, RequestExecutor},
 	chain_head_subscription::ChainHeadSubscription,
 	chain_subscription::ChainSubscriptionEvent,
 	collector,
@@ -100,6 +100,9 @@ pub(crate) struct ParachainTracerOptions {
 	/// Defines subscription mode
 	#[clap(flatten)]
 	collector_opts: CollectorOptions,
+	/// Defines client to communicate with rpc node.
+	#[clap(long = "client", default_value_t, value_enum)]
+	pub api_client_mode: ApiClientMode,
 	/// Run in historical mode to trace parachains between specific blocks instead of following live chain progress
 	#[clap(name = "historical", long, requires = "from", requires = "to", conflicts_with = "subscribe_mode")]
 	is_historical: bool,
@@ -148,16 +151,16 @@ impl ParachainTracer {
 			self.metrics = prometheus::run_prometheus_endpoint(prometheus_opts).await?;
 		}
 
-		let mut collector =
-			Collector::new(self.opts.node.as_str(), self.opts.collector_opts.clone(), self.retry.clone());
+		let mut collector = Collector::new(
+			self.opts.node.as_str(),
+			self.opts.collector_opts.clone(),
+			self.opts.api_client_mode,
+			self.retry.clone(),
+		);
 		collector.spawn(shutdown_tx).await?;
-		if let Err(e) = print_host_configuration(self.opts.node.as_str(), &mut collector.executor()).await {
-			warn!("Cannot get host configuration");
-			return Err(e)
-		}
 
 		println!(
-			"{} will trace {} on {}\n{}",
+			"{}\n\twill trace {}\n\ton {}\n\tusing {} Client",
 			"Parachain Tracer".to_string().purple(),
 			if self.opts.all {
 				"all parachain(s)".to_string()
@@ -165,6 +168,14 @@ impl ParachainTracer {
 				format!("parachain(s) {}", self.opts.para_id.iter().join(","))
 			},
 			&self.node,
+			self.opts.api_client_mode,
+		);
+		if let Err(e) = print_host_configuration(self.opts.node.as_str(), &mut collector.executor()).await {
+			warn!("Cannot get host configuration");
+			return Err(e)
+		}
+		println!(
+			"{}",
 			"-----------------------------------------------------------------------"
 				.to_string()
 				.bold()
@@ -388,9 +399,9 @@ async fn main() -> color_eyre::Result<()> {
 	let mut futures = vec![];
 	let mut sub: Box<dyn EventStream<Event = ChainSubscriptionEvent>> = if opts.is_historical {
 		let (from, to) = historical_bounds(&opts)?;
-		Box::new(HistoricalSubscription::new(vec![opts.node.clone()], from, to, opts.retry.clone()))
+		Box::new(HistoricalSubscription::new(vec![opts.node.clone()], from, to, opts.api_client_mode, opts.retry.clone()))
 	} else {
-		Box::new(ChainHeadSubscription::new(vec![opts.node.clone()], opts.retry.clone()))
+		Box::new(ChainHeadSubscription::new(vec![opts.node.clone()], opts.api_client_mode, opts.retry.clone()))
 	};
 	let consumer_init = sub.create_consumer();
 

--- a/parachain-tracer/src/main.rs
+++ b/parachain-tracer/src/main.rs
@@ -399,7 +399,13 @@ async fn main() -> color_eyre::Result<()> {
 	let mut futures = vec![];
 	let mut sub: Box<dyn EventStream<Event = ChainSubscriptionEvent>> = if opts.is_historical {
 		let (from, to) = historical_bounds(&opts)?;
-		Box::new(HistoricalSubscription::new(vec![opts.node.clone()], from, to, opts.api_client_mode, opts.retry.clone()))
+		Box::new(HistoricalSubscription::new(
+			vec![opts.node.clone()],
+			from,
+			to,
+			opts.api_client_mode,
+			opts.retry.clone(),
+		))
 	} else {
 		Box::new(ChainHeadSubscription::new(vec![opts.node.clone()], opts.api_client_mode, opts.retry.clone()))
 	};

--- a/parachain-tracer/src/message_queues_tracker.rs
+++ b/parachain-tracer/src/message_queues_tracker.rs
@@ -15,7 +15,7 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 
 use log::debug;
-use polkadot_introspector_essentials::api::subxt_wrapper::SubxtHrmpChannel;
+use polkadot_introspector_essentials::types::SubxtHrmpChannel;
 use std::collections::BTreeMap;
 
 #[derive(Default)]

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -16,7 +16,7 @@
 use crate::parachain_block_info::ParachainBlockInfo;
 use parity_scale_codec::Encode;
 use polkadot_introspector_essentials::{
-	api::{storage::RequestExecutor, subxt_wrapper::SubxtHrmpChannel, ApiService},
+	api::{storage::RequestExecutor, ApiService},
 	collector::{
 		candidate_record::{CandidateInclusionRecord, CandidateRecord},
 		CollectorPrefixType,
@@ -39,7 +39,7 @@ use polkadot_introspector_essentials::{
 		},
 	},
 	storage::{RecordTime, RecordsStorageConfig, StorageEntry},
-	types::H256,
+	types::{SubxtHrmpChannel, H256},
 };
 use std::{collections::BTreeMap, time::Duration};
 use subxt::utils::bits::DecodedBits;

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -16,7 +16,7 @@
 use crate::parachain_block_info::ParachainBlockInfo;
 use parity_scale_codec::Encode;
 use polkadot_introspector_essentials::{
-	api::{storage::RequestExecutor, ApiService},
+	api::{storage::RequestExecutor, subxt_wrapper::ApiClientMode, ApiService},
 	collector::{
 		candidate_record::{CandidateInclusionRecord, CandidateRecord},
 		CollectorPrefixType,
@@ -128,11 +128,16 @@ pub fn create_inherent_data(para_id: u32) -> InherentData<Header<u32, BlakeTwo25
 }
 
 pub fn create_api() -> ApiService<H256> {
-	ApiService::new_with_storage(RecordsStorageConfig { max_blocks: 4 }, Default::default())
+	ApiService::new_with_storage(RecordsStorageConfig { max_blocks: 4 }, ApiClientMode::Online, Default::default())
 }
 
 pub fn create_storage() -> RequestExecutor<H256, CollectorPrefixType> {
-	ApiService::new_with_prefixed_storage(RecordsStorageConfig { max_blocks: 4 }, Default::default()).storage()
+	ApiService::new_with_prefixed_storage(
+		RecordsStorageConfig { max_blocks: 4 },
+		ApiClientMode::Online,
+		Default::default(),
+	)
+	.storage()
 }
 
 pub fn create_hrmp_channels() -> BTreeMap<u32, SubxtHrmpChannel> {

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -128,13 +128,13 @@ pub fn create_inherent_data(para_id: u32) -> InherentData<Header<u32, BlakeTwo25
 }
 
 pub fn create_api() -> ApiService<H256> {
-	ApiService::new_with_storage(RecordsStorageConfig { max_blocks: 4 }, ApiClientMode::Online, Default::default())
+	ApiService::new_with_storage(RecordsStorageConfig { max_blocks: 4 }, ApiClientMode::RPC, Default::default())
 }
 
 pub fn create_storage() -> RequestExecutor<H256, CollectorPrefixType> {
 	ApiService::new_with_prefixed_storage(
 		RecordsStorageConfig { max_blocks: 4 },
-		ApiClientMode::Online,
+		ApiClientMode::RPC,
 		Default::default(),
 	)
 	.storage()

--- a/parachain-tracer/src/tracker_rpc.rs
+++ b/parachain-tracer/src/tracker_rpc.rs
@@ -17,8 +17,8 @@
 use async_trait::async_trait;
 use mockall::automock;
 use polkadot_introspector_essentials::{
-	api::subxt_wrapper::{RequestExecutor, SubxtHrmpChannel, SubxtWrapperError},
-	types::H256,
+	api::subxt_wrapper::{RequestExecutor, SubxtWrapperError},
+	types::{SubxtHrmpChannel, H256},
 };
 use std::collections::BTreeMap;
 
@@ -79,7 +79,7 @@ mod tests {
 	async fn setup_client() -> (ParachainTrackerRpc, H256) {
 		let api = create_api();
 		let rpc = ParachainTrackerRpc::new(100, rpc_node_url(), api.subxt());
-		let block_hash = api.subxt().get_block(rpc_node_url(), None).await.unwrap().header().parent_hash;
+		let block_hash = api.subxt().get_block_hash(rpc_node_url(), None).await.unwrap().unwrap();
 
 		(rpc, block_hash)
 	}

--- a/parachain-tracer/src/tracker_storage.rs
+++ b/parachain-tracer/src/tracker_storage.rs
@@ -136,7 +136,7 @@ mod tests {
 	fn setup_client() -> (TrackerStorage, CollectorStorageApi) {
 		let api: CollectorStorageApi = ApiService::new_with_prefixed_storage(
 			RecordsStorageConfig { max_blocks: 4 },
-			ApiClientMode::Online,
+			ApiClientMode::RPC,
 			Default::default(),
 		);
 		let storage = TrackerStorage::new(100, api.storage());

--- a/parachain-tracer/src/tracker_storage.rs
+++ b/parachain-tracer/src/tracker_storage.rs
@@ -15,10 +15,10 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 
 use polkadot_introspector_essentials::{
-	api::{storage::RequestExecutor, subxt_wrapper::InherentData},
+	api::storage::RequestExecutor,
 	collector::{candidate_record::CandidateRecord, CollectorPrefixType, DisputeInfo},
 	metadata::polkadot_primitives::ValidatorIndex,
-	types::{AccountId32, CoreOccupied, OnDemandOrder, Timestamp, H256},
+	types::{AccountId32, CoreOccupied, InherentData, OnDemandOrder, Timestamp, H256},
 };
 use std::collections::BTreeMap;
 use subxt::config::{substrate::BlakeTwo256, Hasher};

--- a/parachain-tracer/src/tracker_storage.rs
+++ b/parachain-tracer/src/tracker_storage.rs
@@ -125,7 +125,7 @@ mod tests {
 
 	use super::*;
 	use polkadot_introspector_essentials::{
-		api::ApiService,
+		api::{subxt_wrapper::ApiClientMode, ApiService},
 		chain_events::SubxtDispute,
 		collector::CollectorStorageApi,
 		storage::{RecordTime, RecordsStorageConfig, StorageEntry},
@@ -134,8 +134,11 @@ mod tests {
 	use subxt::utils::AccountId32;
 
 	fn setup_client() -> (TrackerStorage, CollectorStorageApi) {
-		let api: CollectorStorageApi =
-			ApiService::new_with_prefixed_storage(RecordsStorageConfig { max_blocks: 4 }, Default::default());
+		let api: CollectorStorageApi = ApiService::new_with_prefixed_storage(
+			RecordsStorageConfig { max_blocks: 4 },
+			ApiClientMode::Online,
+			Default::default(),
+		);
 		let storage = TrackerStorage::new(100, api.storage());
 
 		(storage, api)

--- a/parachain-tracer/src/types.rs
+++ b/parachain-tracer/src/types.rs
@@ -19,10 +19,9 @@ use color_eyre::owo_colors::OwoColorize;
 use crossterm::style::Stylize;
 use parity_scale_codec::{Decode, Encode};
 use polkadot_introspector_essentials::{
-	api::subxt_wrapper::SubxtHrmpChannel,
 	chain_events::SubxtDisputeResult,
 	metadata::polkadot_primitives::DisputeStatementSet,
-	types::{AccountId32, BlockNumber, Timestamp, H256},
+	types::{AccountId32, BlockNumber, SubxtHrmpChannel, Timestamp, H256},
 };
 use std::{
 	fmt::{self, Display, Formatter, Write},

--- a/parachain-tracer/src/utils.rs
+++ b/parachain-tracer/src/utils.rs
@@ -15,9 +15,8 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 
 use polkadot_introspector_essentials::{
-	api::subxt_wrapper::InherentData,
 	metadata::polkadot_primitives::{AvailabilityBitfield, BackedCandidate, DisputeStatement, DisputeStatementSet},
-	types::{AccountId32, Timestamp, H256},
+	types::{AccountId32, InherentData, Timestamp, H256},
 };
 use std::time::Duration;
 

--- a/whois/src/main.rs
+++ b/whois/src/main.rs
@@ -92,7 +92,7 @@ impl Whois {
 		self,
 		consumer_config: EventConsumerInit<TelemetryEvent>,
 	) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>, WhoisError> {
-		let mut executor = RequestExecutor::new(ApiClientMode::Online, self.opts.retry.clone());
+		let mut executor = RequestExecutor::new(ApiClientMode::RPC, self.opts.retry.clone());
 		let validator = match self.opts.command {
 			WhoisCommand::Account(v) => v.validator,
 			WhoisCommand::Session(v) => match executor.get_session_account_keys(&self.opts.ws, v.session_index).await {

--- a/whois/src/main.rs
+++ b/whois/src/main.rs
@@ -16,7 +16,7 @@
 
 use clap::{Args, Parser, Subcommand};
 use polkadot_introspector_essentials::{
-	api::subxt_wrapper::{RequestExecutor, SubxtWrapperError},
+	api::subxt_wrapper::{ApiClientMode, RequestExecutor, SubxtWrapperError},
 	consumer::{EventConsumerInit, EventStream},
 	init,
 	telemetry_feed::{AddedNode, TelemetryFeed},
@@ -92,7 +92,7 @@ impl Whois {
 		self,
 		consumer_config: EventConsumerInit<TelemetryEvent>,
 	) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>, WhoisError> {
-		let mut executor = RequestExecutor::new(self.opts.retry.clone());
+		let mut executor = RequestExecutor::new(ApiClientMode::Online, self.opts.retry.clone());
 		let validator = match self.opts.command {
 			WhoisCommand::Account(v) => v.validator,
 			WhoisCommand::Session(v) => match executor.get_session_account_keys(&self.opts.ws, v.session_index).await {


### PR DESCRIPTION
Last version of subxt supports light client via smoldot. It can help us to reduce costs on running additional rpc nodes.

Optional light client added to parachain tracer. Other tools use only online (old) client. 

Currently, light client seems not stable to work with introspector. But it can be solved in subxt and smoldot crates. 