### PR TITLE
Update types for metadata v5

### DIFF
--- a/essentials/src/api/api_client.rs
+++ b/essentials/src/api/api_client.rs
@@ -141,7 +141,7 @@ impl<T: OnlineClientT<PolkadotConfig>> ApiClientT for ApiClient<T> {
 		block_hash: H256,
 		para_id: u32,
 	) -> Result<BTreeMap<u32, SubxtHrmpChannel>, subxt::Error> {
-		use polkadot::runtime_types::polkadot_parachain::primitives::{HrmpChannelId, Id};
+		use polkadot::runtime_types::polkadot_parachain_primitives::primitives::{HrmpChannelId, Id};
 		let addr = polkadot::storage().hrmp().hrmp_ingress_channels_index(&Id(para_id));
 		let hrmp_channels = self.storage().at(block_hash).fetch(&addr).await?.unwrap_or_default();
 		let mut channels_configuration: BTreeMap<u32, SubxtHrmpChannel> = BTreeMap::new();
@@ -164,7 +164,7 @@ impl<T: OnlineClientT<PolkadotConfig>> ApiClientT for ApiClient<T> {
 		block_hash: H256,
 		para_id: u32,
 	) -> Result<BTreeMap<u32, SubxtHrmpChannel>, subxt::Error> {
-		use polkadot::runtime_types::polkadot_parachain::primitives::{HrmpChannelId, Id};
+		use polkadot::runtime_types::polkadot_parachain_primitives::primitives::{HrmpChannelId, Id};
 
 		let addr = polkadot::storage().hrmp().hrmp_egress_channels_index(&Id(para_id));
 		let hrmp_channels = self.storage().at(block_hash).fetch(&addr).await?.unwrap_or_default();

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -2,7 +2,7 @@ use super::subxt_wrapper::SubxtWrapperError::{self, DecodeDynamicError};
 use crate::{
 	metadata::{
 		polkadot::runtime_types::{
-			polkadot_parachain::primitives::Id, polkadot_runtime_parachains::scheduler::AssignmentKind,
+			polkadot_parachain_primitives::primitives::Id, polkadot_runtime_parachains::scheduler::AssignmentKind,
 		},
 		polkadot_primitives::{CoreIndex, ValidatorIndex},
 	},

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -1,12 +1,7 @@
 use super::subxt_wrapper::SubxtWrapperError::{self, DecodeDynamicError};
 use crate::{
-	metadata::{
-		polkadot::runtime_types::{
-			polkadot_parachain_primitives::primitives::Id, polkadot_runtime_parachains::scheduler::AssignmentKind,
-		},
-		polkadot_primitives::{CoreIndex, ValidatorIndex},
-	},
-	types::{Assignment, BlockNumber, ClaimQueue, CoreAssignment, CoreOccupied, OnDemandOrder, ParasEntry},
+	metadata::polkadot_primitives::ValidatorIndex,
+	types::{Assignment, BlockNumber, ClaimQueue, CoreOccupied, OnDemandOrder, ParasEntry},
 };
 use log::error;
 use std::collections::{BTreeMap, VecDeque};
@@ -56,24 +51,6 @@ pub(crate) fn decode_availability_cores(raw_cores: &Value<u32>) -> Result<Vec<Co
 	}
 
 	Ok(cores)
-}
-
-pub(crate) fn decode_scheduled_paras(raw_paras: &Value<u32>) -> Result<Vec<CoreAssignment>, SubxtWrapperError> {
-	let decoded_paras = decode_unnamed_composite(raw_paras)?;
-	let mut paras = Vec::with_capacity(decoded_paras.len());
-	for para in decoded_paras.iter() {
-		let core = CoreIndex(decode_composite_u128_value(value_at("core", para)?)? as u32);
-		let para_id = Id(decode_composite_u128_value(value_at("para_id", para)?)? as u32);
-		let kind = match decode_variant(value_at("kind", para)?)?.name.as_str() {
-			"Parachain" => AssignmentKind::Parachain,
-			name => todo!("Add support for {name}"),
-		};
-		let assignment = CoreAssignment { core, para_id, kind };
-
-		paras.push(assignment)
-	}
-
-	Ok(paras)
 }
 
 pub(crate) fn decode_claim_queue(raw: &Value<u32>) -> Result<ClaimQueue, SubxtWrapperError> {

--- a/essentials/src/api/mod.rs
+++ b/essentials/src/api/mod.rs
@@ -150,21 +150,6 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn get_scheduled_paras() {
-		let api = ApiService::<H256>::new_with_storage(
-			RecordsStorageConfig { max_blocks: 1 },
-			ApiClientMode::RPC,
-			RetryOptions::default(),
-		);
-		let mut subxt = api.subxt();
-
-		let head = subxt.get_block_head(rpc_node_url(), None).await.unwrap().unwrap();
-		let paras = subxt.get_scheduled_paras(rpc_node_url(), head.hash()).await;
-
-		assert!(paras.is_ok());
-	}
-
-	#[tokio::test]
 	async fn get_occupied_cores() {
 		let api = ApiService::<H256>::new_with_storage(
 			RecordsStorageConfig { max_blocks: 1 },

--- a/essentials/src/metadata.rs
+++ b/essentials/src/metadata.rs
@@ -18,4 +18,4 @@
 #[subxt::subxt(runtime_metadata_path = "assets/polkadot_metadata.scale")]
 pub mod polkadot {}
 
-pub use polkadot::runtime_types::polkadot_primitives::v4 as polkadot_primitives;
+pub use polkadot::runtime_types::polkadot_primitives::v5 as polkadot_primitives;

--- a/essentials/src/types.rs
+++ b/essentials/src/types.rs
@@ -18,7 +18,9 @@
 use crate::metadata::{
 	polkadot::{
 		runtime_types as subxt_runtime_types,
-		runtime_types::{polkadot_parachain::primitives::Id, polkadot_runtime_parachains::scheduler::AssignmentKind},
+		runtime_types::{
+			polkadot_parachain_primitives::primitives::Id, polkadot_runtime_parachains::scheduler::AssignmentKind,
+		},
 	},
 	polkadot_primitives,
 };

--- a/essentials/src/types.rs
+++ b/essentials/src/types.rs
@@ -15,15 +15,7 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-use crate::metadata::{
-	polkadot::{
-		runtime_types as subxt_runtime_types,
-		runtime_types::{
-			polkadot_parachain_primitives::primitives::Id, polkadot_runtime_parachains::scheduler::AssignmentKind,
-		},
-	},
-	polkadot_primitives,
-};
+use crate::metadata::{polkadot::runtime_types as subxt_runtime_types, polkadot_primitives};
 use parity_scale_codec::{Decode, Encode};
 use std::collections::{BTreeMap, VecDeque};
 use subxt::{
@@ -42,12 +34,8 @@ pub type SubxtCall = runtime::RuntimeCall;
 pub type ClaimQueue = BTreeMap<u32, VecDeque<Option<ParasEntry>>>;
 
 /// The `InherentData` constructed with the subxt API.
-pub type InherentData = polkadot_primitives::InherentData<
-	subxt_runtime_types::sp_runtime::generic::header::Header<
-		::core::primitive::u32,
-		subxt_runtime_types::sp_runtime::traits::BlakeTwo256,
-	>,
->;
+pub type InherentData =
+	polkadot_primitives::InherentData<subxt_runtime_types::sp_runtime::generic::header::Header<::core::primitive::u32>>;
 
 /// A wrapper over subxt HRMP channel configuration
 #[derive(Debug, Clone, Default)]
@@ -75,17 +63,6 @@ impl From<subxt_runtime_types::polkadot_runtime_parachains::hrmp::HrmpChannel> f
 			recipient_deposit: channel.recipient_deposit,
 		}
 	}
-}
-
-// TODO: Take it from runtime types v5
-/// How a free core is scheduled to be assigned.
-pub struct CoreAssignment {
-	/// The core that is assigned.
-	pub core: polkadot_primitives::CoreIndex,
-	/// The unique ID of the para that is assigned to the core.
-	pub para_id: Id,
-	/// The kind of the assignment.
-	pub kind: AssignmentKind,
 }
 
 // TODO: Take it from runtime types v5

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -25,7 +25,7 @@ use polkadot_introspector_essentials::{
 		polkadot::runtime_types::{
 			bounded_collections::bounded_vec::BoundedVec,
 			polkadot_core_primitives::CandidateHash,
-			polkadot_parachain::primitives::{HeadData, Id, ValidationCodeHash},
+			polkadot_parachain_primitives::primitives::{HeadData, Id, ValidationCodeHash},
 			sp_core::sr25519::{Public, Signature},
 			sp_runtime::{
 				generic::{digest::Digest, header::Header},

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -27,10 +27,7 @@ use polkadot_introspector_essentials::{
 			polkadot_core_primitives::CandidateHash,
 			polkadot_parachain_primitives::primitives::{HeadData, Id, ValidationCodeHash},
 			sp_core::sr25519::{Public, Signature},
-			sp_runtime::{
-				generic::{digest::Digest, header::Header},
-				traits::BlakeTwo256,
-			},
+			sp_runtime::generic::{digest::Digest, header::Header},
 		},
 		polkadot_primitives::{
 			collator_app, signed::UncheckedSigned, validator_app, AvailabilityBitfield, BackedCandidate,
@@ -106,7 +103,7 @@ pub fn create_dispute_statement_set() -> DisputeStatementSet {
 	}
 }
 
-pub fn create_inherent_data(para_id: u32) -> InherentData<Header<u32, BlakeTwo256>> {
+pub fn create_inherent_data(para_id: u32) -> InherentData<Header<u32>> {
 	InherentData {
 		bitfields: vec![UncheckedSigned {
 			payload: AvailabilityBitfield(DecodedBits::from_iter([true])),
@@ -122,7 +119,6 @@ pub fn create_inherent_data(para_id: u32) -> InherentData<Header<u32, BlakeTwo25
 			state_root: Default::default(),
 			extrinsics_root: Default::default(),
 			digest: Digest { logs: Default::default() },
-			__subxt_unused_type_params: Default::default(),
 		},
 	}
 }


### PR DESCRIPTION
After we updated the metadata itself from v4 to v5
- Updated metadata types
- Updated paths
- Removed deprecated `GetScheduledParas`