### PR TITLE
Show introspector events as a list

### DIFF
--- a/parachain-tracer/src/main.rs
+++ b/parachain-tracer/src/main.rs
@@ -152,7 +152,7 @@ impl ParachainTracer {
 		collector.spawn(shutdown_tx).await?;
 
 		println!(
-			"{}\n\twill trace {}\n\ton {}\n\tusing {} Client",
+			"{}\n\twill trace {}\n\ton {}\n\tusing {} Client\n",
 			"Parachain Tracer".to_string().purple(),
 			if self.opts.all {
 				"all parachain(s)".to_string()

--- a/parachain-tracer/src/types.rs
+++ b/parachain-tracer/src/types.rs
@@ -182,14 +182,11 @@ impl Display for ParachainProgressUpdate {
 		writeln!(buf, "\t🥝 Availability core {}", if !self.core_occupied { "FREE" } else { "OCCUPIED" })?;
 		writeln!(
 			buf,
-			"\t🐌 Finality lag: {}",
+			"\t🐌 Finality lag: {}{}",
 			self.finality_lag
-				.map_or_else(|| "NA".to_owned(), |lag| format!("{} blocks", lag))
+				.map_or_else(|| "NA".to_owned(), |lag| format!("{} blocks", lag)),
+			if self.events.is_empty() { "" } else { "\n" },
 		)?;
-
-		if !self.events.is_empty() {
-			writeln!(buf, "",)?;
-		}
 		for event in &self.events {
 			write!(buf, "{}", event)?;
 		}

--- a/parachain-tracer/src/types.rs
+++ b/parachain-tracer/src/types.rs
@@ -178,9 +178,6 @@ impl Display for ParachainProgressUpdate {
 				format!("{}", self.para_id).bold(),
 			)?;
 		}
-		for event in &self.events {
-			write!(buf, "{}", event)?;
-		}
 		writeln!(buf, "\t🔗 Relay block hash: {} ", format!("{:?}", self.block_hash).bold())?;
 		writeln!(buf, "\t🥝 Availability core {}", if !self.core_occupied { "FREE" } else { "OCCUPIED" })?;
 		writeln!(
@@ -189,6 +186,13 @@ impl Display for ParachainProgressUpdate {
 			self.finality_lag
 				.map_or_else(|| "NA".to_owned(), |lag| format!("{} blocks", lag))
 		)?;
+
+		if !self.events.is_empty() {
+			writeln!(buf, "",)?;
+		}
+		for event in &self.events {
+			write!(buf, "{}", event)?;
+		}
 		f.write_str(buf.as_str())
 	}
 }
@@ -200,41 +204,41 @@ impl Display for ParachainConsensusEvent {
 				writeln!(f, "\t- Parachain assigned to core index {}", core_id)
 			},
 			ParachainConsensusEvent::Backed(candidate_hash) => {
-				writeln!(f, "\t{}", "CANDIDATE BACKED".to_string().bold().green())?;
-				writeln!(f, "\t💜 Candidate hash: {} ", format!("{:?}", candidate_hash).magenta())
+				writeln!(f, "\t- {}", "CANDIDATE BACKED".to_string().bold().green())?;
+				writeln!(f, "\t  💜 Candidate hash: {} ", format!("{:?}", candidate_hash).magenta())
 			},
 			ParachainConsensusEvent::Included(candidate_hash, bits_available, max_bits) => {
-				writeln!(f, "\t{}", "CANDIDATE INCLUDED".to_string().bold().green())?;
-				writeln!(f, "\t💜 Candidate hash: {} ", format!("{:?}", candidate_hash).magenta())?;
-				writeln!(f, "\t🟢 Availability bits: {}/{}", bits_available, max_bits)
+				writeln!(f, "\t- {}", "CANDIDATE INCLUDED".to_string().bold().green())?;
+				writeln!(f, "\t  💜 Candidate hash: {} ", format!("{:?}", candidate_hash).magenta())?;
+				writeln!(f, "\t  🟢 Availability bits: {}/{}", bits_available, max_bits)
 			},
 			ParachainConsensusEvent::Disputed(outcome) => {
-				writeln!(f, "\t{}", "💔 Dispute tracked:".to_string().bold())?;
+				writeln!(f, "\t- {}", "💔 Dispute tracked:".to_string().bold())?;
 				write!(f, "{}", outcome)
 			},
 			ParachainConsensusEvent::SkippedSlot => {
-				writeln!(f, "\t{}, no candidate backed", "SLOW BACKING".to_string().bold().red(),)
+				writeln!(f, "\t- {}, no candidate backed", "SLOW BACKING".to_string().bold().red(),)
 			},
 			ParachainConsensusEvent::SlowAvailability(bits_available, max_bits) => {
-				writeln!(f, "\t{}", "SLOW AVAILABILITY".to_string().bold().yellow())?;
-				writeln!(f, "\t🟢 Availability bits: {}/{}", bits_available, max_bits)
+				writeln!(f, "\t- {}", "SLOW AVAILABILITY".to_string().bold().yellow())?;
+				writeln!(f, "\t  🟢 Availability bits: {}/{}", bits_available, max_bits)
 			},
 			ParachainConsensusEvent::SlowBitfieldPropagation(bitfields_count, max_bits) => {
 				writeln!(
 					f,
-					"\t{} bitfield count {}/{}",
+					"\t- {} bitfield count {}/{}",
 					"SLOW BITFIELD PROPAGATION".to_string().dark_red(),
 					bitfields_count,
 					max_bits
 				)
 			},
 			ParachainConsensusEvent::NewSession(session_index) => {
-				writeln!(f, "\t✨ New session tracked: {}", session_index)
+				writeln!(f, "\t- ✨ New session tracked: {}", session_index)
 			},
 			ParachainConsensusEvent::MessageQueues(inbound, outbound) => {
 				if !inbound.is_empty() {
 					let total: u32 = inbound.iter().map(|(_, channel)| channel.total_size).sum();
-					writeln!(f, "\t👉 Inbound HRMP messages, received {} bytes in total", total)?;
+					writeln!(f, "\t- 👉 Inbound HRMP messages, received {} bytes in total", total)?;
 
 					for (peer_parachain, channel) in inbound {
 						if channel.total_size > 0 {
@@ -248,7 +252,7 @@ impl Display for ParachainConsensusEvent {
 				}
 				if !outbound.is_empty() {
 					let total: u32 = inbound.iter().map(|(_, channel)| channel.total_size).sum();
-					writeln!(f, "\t👉 Outbound HRMP messages, sent {} bytes in total", total)?;
+					writeln!(f, "\t- 👉 Outbound HRMP messages, sent {} bytes in total", total)?;
 
 					for (peer_parachain, channel) in outbound {
 						if channel.total_size > 0 {


### PR DESCRIPTION
Each introspectors "event" as a separated list item: 

Was
```
2024-02-13T11:33:42.000000000Z +0ms [#9171228]; parachain: 1005
	✨ New session tracked: 15712
	- Parachain assigned to core index 3
	CANDIDATE BACKED
	💜 Candidate hash: 0x4718ed1e1311c00bdf9ee424f8e3100f58979eaa74d1249022885eb53bd29095
	🔗 Relay block hash: 0x68b8d6290839b26c9fe35d7787d8f7f0ef5e2e8c590ea23a7ac696d1b185840f
	🥝 Availability core OCCUPIED
	🐌 Finality lag: NA
```


Now
```
2024-02-13T11:31:48.001000000Z +0ms [#9171209]; parachain: 1005
	🔗 Relay block hash: 0xbb99fb08c06fd5cd6919a26390249865fcf81aac2645cc8fa5fb08d13735ec0b
	🥝 Availability core OCCUPIED
	🐌 Finality lag: NA

	- ✨ New session tracked: 15712
	- Parachain assigned to core index 3
	- CANDIDATE INCLUDED
	  💜 Candidate hash: 0xde2260946dcdc3f2f538cda8d8e5f5fe060a862e41fac60a0b7e50eb4a814ee6
	  🟢 Availability bits: 109/110
```

