### PR TITLE
Fix candidate tracking on async backing

### DIFF
--- a/essentials/src/chain_events.rs
+++ b/essentials/src/chain_events.rs
@@ -73,6 +73,8 @@ pub struct SubxtCandidateEvent {
 	pub parachain_id: u32,
 	/// The event type
 	pub event_type: SubxtCandidateEventType,
+	/// Core index
+	pub core_idx: u32,
 }
 
 /// A helper structure to keep track of a dispute and it's relay parent
@@ -126,6 +128,7 @@ pub async fn decode_chain_event<T: subxt::Config>(
 		return Ok(ChainEvent::CandidateChanged(Box::new(create_candidate_event(
 			decoded.0.commitments_hash,
 			decoded.0.descriptor,
+			decoded.2 .0,
 			SubxtCandidateEventType::Backed,
 		))))
 	}
@@ -135,6 +138,7 @@ pub async fn decode_chain_event<T: subxt::Config>(
 		return Ok(ChainEvent::CandidateChanged(Box::new(create_candidate_event(
 			decoded.0.commitments_hash,
 			decoded.0.descriptor,
+			decoded.2 .0,
 			SubxtCandidateEventType::Included,
 		))))
 	}
@@ -144,6 +148,7 @@ pub async fn decode_chain_event<T: subxt::Config>(
 		return Ok(ChainEvent::CandidateChanged(Box::new(create_candidate_event(
 			decoded.0.commitments_hash,
 			decoded.0.descriptor,
+			decoded.2 .0,
 			SubxtCandidateEventType::TimedOut,
 		))))
 	}
@@ -190,9 +195,10 @@ fn decode_to_specific_event<E: subxt::events::StaticEvent, C: subxt::Config>(
 fn create_candidate_event(
 	commitments_hash: <PolkadotConfig as subxt::Config>::Hash,
 	candidate_descriptor: CandidateDescriptor<<PolkadotConfig as subxt::Config>::Hash>,
+	core_idx: u32,
 	event_type: SubxtCandidateEventType,
 ) -> SubxtCandidateEvent {
 	let candidate_hash = BlakeTwo256::hash_of(&(&candidate_descriptor, commitments_hash));
 	let parachain_id = candidate_descriptor.para_id.0;
-	SubxtCandidateEvent { event_type, candidate_descriptor, parachain_id, candidate_hash }
+	SubxtCandidateEvent { event_type, candidate_descriptor, parachain_id, candidate_hash, core_idx }
 }

--- a/essentials/src/collector/candidate_record.rs
+++ b/essentials/src/collector/candidate_record.rs
@@ -109,6 +109,11 @@ pub struct CandidateRecord {
 }
 
 impl CandidateRecord {
+	/// Returns if a candidate has been included
+	pub fn is_included(&self) -> bool {
+		self.candidate_inclusion.included.is_some()
+	}
+
 	/// Returns if a candidate has been disputed
 	#[allow(dead_code)]
 	pub fn is_disputed(&self) -> bool {

--- a/essentials/src/collector/candidate_record.rs
+++ b/essentials/src/collector/candidate_record.rs
@@ -35,7 +35,7 @@ pub struct CandidateInclusionRecord<T: Encode + Decode + Clone> {
 	/// Relay parent block number when a candidate was timed out
 	pub timedout: Option<u32>,
 	/// Observed core index
-	pub core_idx: Option<u32>,
+	pub core_idx: u32,
 	/// Stated relay parent
 	pub relay_parent: T,
 	/// Stated relay parent number
@@ -143,5 +143,9 @@ impl CandidateRecord {
 
 	pub fn parachain_id(&self) -> u32 {
 		self.candidate_inclusion.parachain_id
+	}
+
+	pub fn core_idx(&self) -> u32 {
+		self.candidate_inclusion.core_idx
 	}
 }

--- a/essentials/src/collector/mod.rs
+++ b/essentials/src/collector/mod.rs
@@ -798,7 +798,7 @@ impl Collector {
 							relay_parent_number: relay_parent.number,
 							parachain_id: change_event.parachain_id,
 							backed: relay_block_number,
-							core_idx: None,
+							core_idx: change_event.core_idx,
 							timedout: None,
 							included: None,
 						};

--- a/parachain-tracer/src/parachain_block_info.rs
+++ b/parachain-tracer/src/parachain_block_info.rs
@@ -48,11 +48,6 @@ impl ParachainBlockInfo {
 		BlakeTwo256::hash_of(&(&candidate.candidate.descriptor, commitments_hash))
 	}
 
-	#[cfg(test)]
-	pub fn set_backed(&mut self) {
-		self.state = ParachainBlockState::Backed
-	}
-
 	pub fn set_pending(&mut self) {
 		self.state = ParachainBlockState::PendingAvailability
 	}
@@ -96,12 +91,9 @@ mod tests {
 		assert!(!info.is_bitfield_propagation_slow());
 
 		info.max_availability_bits = 200;
-		assert!(!info.is_bitfield_propagation_slow());
+		assert!(info.is_bitfield_propagation_slow());
 
-		info.bitfield_count = 100;
-		assert!(!info.is_bitfield_propagation_slow());
-
-		info.set_backed();
+		info.bitfield_count = 120;
 		assert!(info.is_bitfield_propagation_slow());
 	}
 }

--- a/parachain-tracer/src/parachain_block_info.rs
+++ b/parachain-tracer/src/parachain_block_info.rs
@@ -35,7 +35,7 @@ pub struct ParachainBlockInfo {
 	/// Core occupation status.
 	pub core_occupied: bool,
 	/// The current state.
-	state: Vec<ParachainBlockState>,
+	state: ParachainBlockState,
 }
 
 impl ParachainBlockInfo {
@@ -49,40 +49,35 @@ impl ParachainBlockInfo {
 	}
 
 	pub fn set_idle(&mut self) {
-		self.state.push(ParachainBlockState::Idle)
+		self.state = ParachainBlockState::Idle
 	}
 
 	pub fn set_backed(&mut self) {
-		self.state.push(ParachainBlockState::Backed)
+		self.state = ParachainBlockState::Backed
 	}
 
 	pub fn set_pending(&mut self) {
-		self.state.push(ParachainBlockState::PendingAvailability)
+		self.state = ParachainBlockState::PendingAvailability
 	}
 
 	pub fn set_included(&mut self) {
-		self.state.push(ParachainBlockState::Included)
+		self.state = ParachainBlockState::Included
 	}
 
 	pub fn is_idle(&self) -> bool {
-		self.state.last() == Some(&ParachainBlockState::Idle)
+		self.state == ParachainBlockState::Idle
 	}
 
 	pub fn is_backed(&self) -> bool {
-		self.state.last() == Some(&ParachainBlockState::Backed)
+		self.state == ParachainBlockState::Backed
 	}
 
 	pub fn is_pending(&self) -> bool {
-		self.state.last() == Some(&ParachainBlockState::PendingAvailability)
+		self.state == ParachainBlockState::PendingAvailability
 	}
 
 	pub fn is_included(&self) -> bool {
-		self.state.last() == Some(&ParachainBlockState::Included)
-	}
-
-	pub fn has_state_changed(&self) -> bool {
-		let len = self.state.len();
-		len == 1 || len > 1 && self.state[len - 2] != self.state[len - 1]
+		self.state == ParachainBlockState::Included
 	}
 
 	pub fn is_bitfield_propagation_slow(&self) -> bool {

--- a/parachain-tracer/src/parachain_block_info.rs
+++ b/parachain-tracer/src/parachain_block_info.rs
@@ -89,10 +89,6 @@ impl ParachainBlockInfo {
 		len == 1 || len > 1 && self.state[len - 2] != self.state[len - 1]
 	}
 
-	pub fn is_data_available(&self) -> bool {
-		self.current_availability_bits > (self.max_availability_bits / 3) * 2
-	}
-
 	pub fn is_bitfield_propagation_slow(&self) -> bool {
 		self.max_availability_bits > 0 && !self.is_idle() && self.bitfield_count <= (self.max_availability_bits / 3) * 2
 	}

--- a/parachain-tracer/src/parachain_block_info.rs
+++ b/parachain-tracer/src/parachain_block_info.rs
@@ -22,12 +22,12 @@ use subxt::config::{substrate::BlakeTwo256, Hasher};
 /// This is used for displaying CLI updates and also goes to Storage.
 #[derive(Encode, Decode, Debug, Default)]
 pub struct ParachainBlockInfo {
-	/// The candidate information as observed during backing
-	pub candidate: Option<BackedCandidate<H256>>,
 	/// Candidate hash
 	pub candidate_hash: Option<H256>,
-	/// The current state.
-	state: ParachainBlockState,
+	/// Relay block number on which the candidate was backed
+	pub backed_at: Option<u32>,
+	/// Relay block number on which the candidate was included
+	pub included_at: Option<u32>,
 	/// The number of signed bitfields.
 	pub bitfield_count: u32,
 	/// The maximum expected number of availability bits that can be set. Corresponds to `max_validators`.
@@ -38,54 +38,55 @@ pub struct ParachainBlockInfo {
 	pub assigned_core: Option<u32>,
 	/// Core occupation status.
 	pub core_occupied: bool,
+	/// The current state.
+	state: Vec<ParachainBlockState>,
 }
 
 impl ParachainBlockInfo {
-	pub fn maybe_reset(&mut self) {
-		if self.is_included() {
-			self.state = ParachainBlockState::Idle;
-			self.candidate = None;
-			self.candidate_hash = None;
-		}
+	pub fn new(candidate_hash: Option<H256>) -> Self {
+		Self { candidate_hash, ..Default::default() }
+	}
+
+	pub fn candidate_hash(candidate: BackedCandidate<H256>) -> H256 {
+		let commitments_hash = BlakeTwo256::hash_of(&candidate.candidate.commitments);
+		BlakeTwo256::hash_of(&(&candidate.candidate.descriptor, commitments_hash))
 	}
 
 	pub fn set_idle(&mut self) {
-		self.state = ParachainBlockState::Idle
+		self.state.push(ParachainBlockState::Idle)
 	}
 
 	pub fn set_backed(&mut self) {
-		self.state = ParachainBlockState::Backed
+		self.state.push(ParachainBlockState::Backed)
 	}
 
 	pub fn set_pending(&mut self) {
-		self.state = ParachainBlockState::PendingAvailability
+		self.state.push(ParachainBlockState::PendingAvailability)
 	}
 
 	pub fn set_included(&mut self) {
-		self.state = ParachainBlockState::Included
-	}
-
-	pub fn set_candidate(&mut self, candidate: BackedCandidate<H256>) {
-		let commitments_hash = BlakeTwo256::hash_of(&candidate.candidate.commitments);
-		let candidate_hash = BlakeTwo256::hash_of(&(&candidate.candidate.descriptor, commitments_hash));
-		self.candidate_hash = Some(candidate_hash);
-		self.candidate = Some(candidate);
+		self.state.push(ParachainBlockState::Included)
 	}
 
 	pub fn is_idle(&self) -> bool {
-		self.state == ParachainBlockState::Idle
+		self.state.last() == Some(&ParachainBlockState::Idle)
 	}
 
 	pub fn is_backed(&self) -> bool {
-		self.state == ParachainBlockState::Backed
+		self.state.last() == Some(&ParachainBlockState::Backed)
 	}
 
 	pub fn is_pending(&self) -> bool {
-		self.state == ParachainBlockState::PendingAvailability
+		self.state.last() == Some(&ParachainBlockState::PendingAvailability)
 	}
 
 	pub fn is_included(&self) -> bool {
-		self.state == ParachainBlockState::Included
+		self.state.last() == Some(&ParachainBlockState::Included)
+	}
+
+	pub fn has_state_changed(&self) -> bool {
+		let len = self.state.len();
+		len == 1 || len > 1 && self.state[len - 2] != self.state[len - 1]
 	}
 
 	pub fn is_data_available(&self) -> bool {
@@ -114,38 +115,6 @@ enum ParachainBlockState {
 #[cfg(test)]
 mod tests {
 	use crate::test_utils::create_para_block_info;
-
-	#[test]
-	fn test_does_not_reset_state_if_not_included() {
-		let mut info = create_para_block_info();
-		info.set_backed();
-
-		assert!(info.is_backed());
-		assert!(info.candidate.is_some());
-		assert!(info.candidate_hash.is_some());
-
-		info.maybe_reset();
-
-		assert!(info.is_backed());
-		assert!(info.candidate.is_some());
-		assert!(info.candidate_hash.is_some());
-	}
-
-	#[test]
-	fn test_resets_state_if_included() {
-		let mut info = create_para_block_info();
-		info.set_included();
-
-		assert!(info.is_included());
-		assert!(info.candidate.is_some());
-		assert!(info.candidate_hash.is_some());
-
-		info.maybe_reset();
-
-		assert!(info.is_idle());
-		assert!(info.candidate.is_none());
-		assert!(info.candidate_hash.is_none());
-	}
 
 	#[test]
 	fn test_is_data_available() {

--- a/parachain-tracer/src/parachain_block_info.rs
+++ b/parachain-tracer/src/parachain_block_info.rs
@@ -43,7 +43,7 @@ impl ParachainBlockInfo {
 		Self { candidate_hash, ..Default::default() }
 	}
 
-	pub fn candidate_hash(candidate: BackedCandidate<H256>) -> H256 {
+	pub fn candidate_hash(candidate: &BackedCandidate<H256>) -> H256 {
 		let commitments_hash = BlakeTwo256::hash_of(&candidate.candidate.commitments);
 		BlakeTwo256::hash_of(&(&candidate.candidate.descriptor, commitments_hash))
 	}
@@ -101,7 +101,7 @@ mod tests {
 
 	#[test]
 	fn test_is_bitfield_propagation_slow() {
-		let mut info = create_para_block_info();
+		let mut info = create_para_block_info(100);
 		assert!(!info.is_bitfield_propagation_slow());
 
 		info.max_availability_bits = 200;

--- a/parachain-tracer/src/parachain_block_info.rs
+++ b/parachain-tracer/src/parachain_block_info.rs
@@ -113,18 +113,9 @@ mod tests {
 	use crate::test_utils::create_para_block_info;
 
 	#[test]
-	fn test_is_data_available() {
-		let mut info = create_para_block_info();
-		assert!(!info.is_data_available());
-
-		info.max_availability_bits = 200;
-		info.current_availability_bits = 134;
-		assert!(info.is_data_available());
-	}
-
-	#[test]
 	fn test_is_bitfield_propagation_slow() {
 		let mut info = create_para_block_info();
+		info.set_idle();
 		assert!(!info.is_bitfield_propagation_slow());
 
 		info.max_availability_bits = 200;

--- a/parachain-tracer/src/parachain_block_info.rs
+++ b/parachain-tracer/src/parachain_block_info.rs
@@ -35,7 +35,7 @@ pub struct ParachainBlockInfo {
 	/// Core occupation status.
 	pub core_occupied: bool,
 	/// The current state.
-	state: ParachainBlockState,
+	pub state: ParachainBlockState,
 }
 
 impl ParachainBlockInfo {
@@ -68,10 +68,6 @@ impl ParachainBlockInfo {
 		self.state == ParachainBlockState::Backed
 	}
 
-	pub fn is_pending(&self) -> bool {
-		self.state == ParachainBlockState::PendingAvailability
-	}
-
 	pub fn is_included(&self) -> bool {
 		self.state == ParachainBlockState::Included
 	}
@@ -83,7 +79,7 @@ impl ParachainBlockInfo {
 
 /// The state of parachain block.
 #[derive(Encode, Decode, Debug, Default, Clone, PartialEq, Eq)]
-enum ParachainBlockState {
+pub enum ParachainBlockState {
 	// Parachain block pipeline is idle.
 	#[default]
 	Idle,

--- a/parachain-tracer/src/parachain_block_info.rs
+++ b/parachain-tracer/src/parachain_block_info.rs
@@ -48,10 +48,6 @@ impl ParachainBlockInfo {
 		BlakeTwo256::hash_of(&(&candidate.candidate.descriptor, commitments_hash))
 	}
 
-	pub fn set_idle(&mut self) {
-		self.state = ParachainBlockState::Idle
-	}
-
 	pub fn set_backed(&mut self) {
 		self.state = ParachainBlockState::Backed
 	}
@@ -106,7 +102,6 @@ mod tests {
 	#[test]
 	fn test_is_bitfield_propagation_slow() {
 		let mut info = create_para_block_info();
-		info.set_idle();
 		assert!(!info.is_bitfield_propagation_slow());
 
 		info.max_availability_bits = 200;

--- a/parachain-tracer/src/parachain_block_info.rs
+++ b/parachain-tracer/src/parachain_block_info.rs
@@ -24,10 +24,6 @@ use subxt::config::{substrate::BlakeTwo256, Hasher};
 pub struct ParachainBlockInfo {
 	/// Candidate hash
 	pub candidate_hash: Option<H256>,
-	/// Relay block number on which the candidate was backed
-	pub backed_at: Option<u32>,
-	/// Relay block number on which the candidate was included
-	pub included_at: Option<u32>,
 	/// The number of signed bitfields.
 	pub bitfield_count: u32,
 	/// The maximum expected number of availability bits that can be set. Corresponds to `max_validators`.

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -165,7 +165,7 @@ pub fn create_candidate_record(
 pub fn create_para_block_info(para_id: u32) -> ParachainBlockInfo {
 	let candidate = create_backed_candidate(para_id);
 	let hash = ParachainBlockInfo::candidate_hash(&candidate);
-	ParachainBlockInfo::new(hash, 0, 120)
+	ParachainBlockInfo::new(hash, 0, 0)
 }
 
 pub async fn storage_write<T: Encode>(

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -152,7 +152,7 @@ pub fn create_candidate_record(
 			backed,
 			included: None,
 			timedout: None,
-			core_idx: None,
+			core_idx: 1,
 			relay_parent,
 			relay_parent_number,
 		},

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -162,8 +162,7 @@ pub fn create_candidate_record(
 }
 
 pub fn create_para_block_info() -> ParachainBlockInfo {
-	let mut info = ParachainBlockInfo::default();
-	info.set_candidate(BackedCandidate {
+	let candidate = BackedCandidate {
 		candidate: CommittedCandidateReceipt {
 			descriptor: CandidateDescriptor {
 				para_id: Id(100),
@@ -187,9 +186,9 @@ pub fn create_para_block_info() -> ParachainBlockInfo {
 		},
 		validity_votes: vec![],
 		validator_indices: DecodedBits::from_iter([true]),
-	});
-
-	info
+	};
+	let hash = ParachainBlockInfo::candidate_hash(candidate);
+	ParachainBlockInfo::new(Some(hash))
 }
 
 pub async fn storage_write<T: Encode>(

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -165,7 +165,7 @@ pub fn create_candidate_record(
 pub fn create_para_block_info(para_id: u32) -> ParachainBlockInfo {
 	let candidate = create_backed_candidate(para_id);
 	let hash = ParachainBlockInfo::candidate_hash(&candidate);
-	ParachainBlockInfo::new(Some(hash))
+	ParachainBlockInfo::new(hash, 0, 120)
 }
 
 pub async fn storage_write<T: Encode>(

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -152,7 +152,7 @@ pub fn create_candidate_record(
 			backed,
 			included: None,
 			timedout: None,
-			core_idx: 1,
+			core_idx: 0,
 			relay_parent,
 			relay_parent_number,
 		},

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -143,6 +143,7 @@ pub fn create_hrmp_channels() -> BTreeMap<u32, SubxtHrmpChannel> {
 pub fn create_candidate_record(
 	para_id: u32,
 	backed: u32,
+	included: Option<u32>,
 	relay_parent: H256,
 	relay_parent_number: u32,
 ) -> CandidateRecord {
@@ -150,7 +151,7 @@ pub fn create_candidate_record(
 		candidate_inclusion: CandidateInclusionRecord {
 			parachain_id: para_id,
 			backed,
-			included: None,
+			included,
 			timedout: None,
 			core_idx: 0,
 			relay_parent,
@@ -161,33 +162,9 @@ pub fn create_candidate_record(
 	}
 }
 
-pub fn create_para_block_info() -> ParachainBlockInfo {
-	let candidate = BackedCandidate {
-		candidate: CommittedCandidateReceipt {
-			descriptor: CandidateDescriptor {
-				para_id: Id(100),
-				relay_parent: Default::default(),
-				collator: collator_app::Public(Public([0; 32])),
-				persisted_validation_data_hash: Default::default(),
-				pov_hash: Default::default(),
-				erasure_root: Default::default(),
-				signature: collator_app::Signature(Signature([0; 64])),
-				para_head: Default::default(),
-				validation_code_hash: ValidationCodeHash(Default::default()),
-			},
-			commitments: CandidateCommitments {
-				upward_messages: BoundedVec(Default::default()),
-				horizontal_messages: BoundedVec(Default::default()),
-				new_validation_code: Default::default(),
-				head_data: HeadData(Default::default()),
-				processed_downward_messages: Default::default(),
-				hrmp_watermark: Default::default(),
-			},
-		},
-		validity_votes: vec![],
-		validator_indices: DecodedBits::from_iter([true]),
-	};
-	let hash = ParachainBlockInfo::candidate_hash(candidate);
+pub fn create_para_block_info(para_id: u32) -> ParachainBlockInfo {
+	let candidate = create_backed_candidate(para_id);
+	let hash = ParachainBlockInfo::candidate_hash(&candidate);
 	ParachainBlockInfo::new(Some(hash))
 }
 

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -836,7 +836,7 @@ mod test_inject_block {
 
 		let block_hash = H256::random();
 		let mut candidate = create_para_block_info(100);
-		let candidate_hash = candidate.candidate_hash.unwrap().clone();
+		let candidate_hash = candidate.candidate_hash.unwrap();
 		candidate.set_backed();
 		tracker.candidates.entry(0).or_default().push(candidate);
 

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -462,10 +462,6 @@ impl SubxtTracker {
 			}
 
 			if candidate.is_pending() {
-				progress.bitfield_health.max_bitfield_count = candidate.max_availability_bits;
-				progress.bitfield_health.available_count = candidate.current_availability_bits;
-				progress.bitfield_health.bitfield_count = candidate.bitfield_count;
-
 				if self.is_slow_availability() {
 					progress.events.push(ParachainConsensusEvent::SlowAvailability(
 						candidate.current_availability_bits,

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -236,7 +236,7 @@ impl SubxtTracker {
 		storage: &TrackerStorage,
 	) {
 		let current_candidate_hash =
-			backed_candidate(backed_candidates, self.para_id).map(|v| ParachainBlockInfo::candidate_hash(v));
+			backed_candidate(backed_candidates, self.para_id).map(ParachainBlockInfo::candidate_hash);
 		let mut current_candidate = ParachainBlockInfo::new(current_candidate_hash);
 
 		if current_candidate.candidate_hash.is_some() {
@@ -441,10 +441,6 @@ impl SubxtTracker {
 		storage: &TrackerStorage,
 	) {
 		for candidate in self.candidates.iter() {
-			if !candidate.has_state_changed() {
-				continue;
-			}
-
 			if candidate.is_idle() {
 				progress.events.push(ParachainConsensusEvent::SkippedSlot);
 				stats.on_skipped_slot(progress);

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -305,7 +305,7 @@ impl SubxtTracker {
 	}
 
 	async fn set_core_assignment(&mut self, block_hash: H256, storage: &TrackerStorage) {
-		for (&core, scheduled_ids) in self.cores.iter() {
+		for (core, scheduled_ids) in self.cores.clone() {
 			if let Some(candidate) = self.current_candidate_mut(core) {
 				if candidate.is_backed() {
 					candidate.core_occupied = matches!(
@@ -353,7 +353,8 @@ impl SubxtTracker {
 		bitfields: Vec<AvailabilityBitfield>,
 		storage: &TrackerStorage,
 	) -> color_eyre::Result<()> {
-		for &core in self.cores.keys() {
+		let core_ids: Vec<u32> = self.cores.keys().cloned().collect();
+		for core in core_ids {
 			if self.is_current_candidate_backed(core) {
 				let is_just_backed = self.is_just_backed();
 				let max_bits = self.validators_indices(block_hash, storage).await?.len() as u32;
@@ -535,11 +536,11 @@ impl SubxtTracker {
 		self.candidates.get(&core).map(|v| v.last()).flatten()
 	}
 
-	fn current_candidate_mut(&self, core: u32) -> Option<&mut ParachainBlockInfo> {
-		self.candidates.get(&core).map(|v| v.last_mut()).flatten()
+	fn current_candidate_mut(&mut self, core: u32) -> Option<&mut ParachainBlockInfo> {
+		self.candidates.get_mut(&core).map(|v| v.last_mut()).flatten()
 	}
 
-	fn all_candidates(&mut self) -> impl Iterator<Item = &ParachainBlockInfo> {
+	fn all_candidates(&self) -> impl Iterator<Item = &ParachainBlockInfo> {
 		self.candidates.iter().flat_map(|(_, v)| v.iter())
 	}
 

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -251,7 +251,7 @@ impl SubxtTracker {
 		for candidate in self.all_candidates_mut() {
 			if let Some(candidate_hash) = candidate.candidate_hash {
 				if let Some(stored_candidate) = storage.candidate(candidate_hash).await {
-					if stored_candidate.candidate_inclusion.included.is_some() {
+					if stored_candidate.is_included() {
 						candidate.set_included();
 						last_included = candidate.candidate_hash;
 					}
@@ -263,10 +263,6 @@ impl SubxtTracker {
 			self.previous_included_at = self.last_included_at;
 			self.last_included_at = self.current_relay_block.map(|v| v.into());
 		}
-	}
-
-	async fn candidate_core(&self, candidate_hash: H256, storage: &TrackerStorage) -> Option<u32> {
-		storage.candidate(candidate_hash).await.map(|v| v.core_idx())
 	}
 
 	async fn set_backed_candidates(
@@ -610,6 +606,10 @@ impl SubxtTracker {
 				.backed
 				.saturating_sub(v.candidate_inclusion.relay_parent_number)
 		})
+	}
+
+	async fn candidate_core(&self, candidate_hash: H256, storage: &TrackerStorage) -> Option<u32> {
+		storage.candidate(candidate_hash).await.map(|v| v.core_idx())
 	}
 }
 

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -996,7 +996,6 @@ mod test_progress {
 
 		// Bitfields propogation is slow
 		let candidate = tracker.candidates.entry(0).or_default().last_mut().unwrap().as_mut().unwrap();
-		candidate.set_backed();
 		candidate.max_availability_bits = 200;
 		mock_stats.expect_on_bitfields().with(eq(120), eq(true)).returning(|_, _| ());
 		mock_metrics
@@ -1167,6 +1166,7 @@ mod test_progress {
 		mock_metrics.expect_init_disputes().returning(|_| ());
 		mock_metrics.expect_on_bitfields().returning(|_, _, _| ());
 		mock_metrics.expect_on_skipped_slot().returning(|_| ());
+		mock_metrics.expect_on_backed().returning(|_| ());
 		mock_metrics.expect_on_block().returning(|_, _| ());
 
 		// With on-demand order
@@ -1253,6 +1253,7 @@ mod test_progress {
 
 		// When candidate is backed
 		let candidate = ParachainBlockInfo::new(candidate_hash, 0, 0);
+		tracker.candidates.clear();
 		tracker.candidates.entry(0).or_default().push(Some(candidate));
 		mock_stats.expect_on_backed().once().returning(|| ());
 		mock_metrics.expect_on_backed().with(eq(100)).once().returning(|_| ());

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -256,9 +256,7 @@ impl SubxtTracker {
 		for candidate in self.candidates.iter_mut() {
 			if let Some(candidate_hash) = candidate.candidate_hash {
 				if let Some(stored_candidate) = storage.candidate(candidate_hash).await {
-					candidate.backed_at = Some(stored_candidate.candidate_inclusion.backed);
-					candidate.included_at = stored_candidate.candidate_inclusion.included;
-					if candidate.included_at.is_some() {
+					if stored_candidate.candidate_inclusion.included.is_some() {
 						candidate.set_included();
 						last_included = candidate.candidate_hash;
 					}
@@ -521,7 +519,7 @@ impl SubxtTracker {
 	}
 
 	fn has_backed_candidate(&self) -> bool {
-		self.candidates.iter().any(|candidate| candidate.backed_at.is_some()) ||
+		self.candidates.iter().any(|candidate| candidate.candidate_hash.is_some()) ||
 			self.relay_forks
 				.iter()
 				.any(|fork| fork.backed_candidate.is_some() || fork.included_candidate.is_some())

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -459,15 +459,13 @@ impl SubxtTracker {
 				}
 			}
 
-			if candidate.is_pending() {
-				if self.is_slow_availability() {
-					progress.events.push(ParachainConsensusEvent::SlowAvailability(
-						candidate.current_availability_bits,
-						candidate.max_availability_bits,
-					));
-					stats.on_slow_availability();
-					metrics.on_slow_availability(self.para_id);
-				}
+			if candidate.is_pending() && self.is_slow_availability() {
+				progress.events.push(ParachainConsensusEvent::SlowAvailability(
+					candidate.current_availability_bits,
+					candidate.max_availability_bits,
+				));
+				stats.on_slow_availability();
+				metrics.on_slow_availability(self.para_id);
 			}
 
 			if candidate.is_included() {

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -533,11 +533,11 @@ impl SubxtTracker {
 	}
 
 	fn current_candidate(&self, core: u32) -> Option<&ParachainBlockInfo> {
-		self.candidates.get(&core).map(|v| v.last()).flatten()
+		self.candidates.get(&core).and_then(|v| v.last())
 	}
 
 	fn current_candidate_mut(&mut self, core: u32) -> Option<&mut ParachainBlockInfo> {
-		self.candidates.get_mut(&core).map(|v| v.last_mut()).flatten()
+		self.candidates.get_mut(&core).and_then(|v| v.last_mut())
 	}
 
 	fn all_candidates(&self) -> impl Iterator<Item = &ParachainBlockInfo> {

--- a/parachain-tracer/src/tracker_storage.rs
+++ b/parachain-tracer/src/tracker_storage.rs
@@ -279,7 +279,7 @@ mod tests {
 				hash,
 				StorageEntry::new_onchain(
 					RecordTime::with_ts(0, Duration::from_secs(0)),
-					create_candidate_record(100, 0, H256::random(), 0),
+					create_candidate_record(100, 0, None, H256::random(), 0),
 				),
 			)
 			.await

--- a/parachain-tracer/src/types.rs
+++ b/parachain-tracer/src/types.rs
@@ -168,7 +168,9 @@ impl Display for ParachainProgressUpdate {
 			)?;
 		}
 		writeln!(buf, "\t🔗 Relay block hash: {} ", format!("{:?}", self.block_hash).bold())?;
-		writeln!(buf, "\t🥝 Availability core {}", if !self.core_occupied { "FREE" } else { "OCCUPIED" })?;
+		for (&core, &core_occupied) in self.core_occupied.iter() {
+			writeln!(buf, "\t🥝 Availability core #{} {}", core, if core_occupied { "OCCUPIED" } else { "FREE" })?;
+		}
 		writeln!(
 			buf,
 			"\t🐌 Finality lag: {}{}",

--- a/parachain-tracer/src/types.rs
+++ b/parachain-tracer/src/types.rs
@@ -99,16 +99,6 @@ impl From<Block> for BlockWithoutHash {
 	}
 }
 
-#[derive(Clone, Default)]
-pub struct BitfieldsHealth {
-	/// Maximum bitfield count, equal to number of parachain validators.
-	pub max_bitfield_count: u32,
-	/// Current bitfield count in the relay chain block.
-	pub bitfield_count: u32,
-	/// Sum of all bits for a given parachain.
-	pub available_count: u32,
-}
-
 #[derive(Clone)]
 /// Events related to parachain blocks from consensus perspective.
 pub enum ParachainConsensusEvent {
@@ -146,8 +136,6 @@ pub struct ParachainProgressUpdate {
 	pub block_number: BlockNumber,
 	/// Relay chain block hash.
 	pub block_hash: H256,
-	/// Bitfields health metrics.
-	pub bitfield_health: BitfieldsHealth,
 	/// Core occupation.
 	pub core_occupied: bool,
 	/// Consensus events happening for the para under a relay parent.

--- a/parachain-tracer/src/types.rs
+++ b/parachain-tracer/src/types.rs
@@ -99,7 +99,7 @@ impl From<Block> for BlockWithoutHash {
 	}
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 /// Events related to parachain blocks from consensus perspective.
 pub enum ParachainConsensusEvent {
 	/// A core has been assigned to a parachain.

--- a/parachain-tracer/src/types.rs
+++ b/parachain-tracer/src/types.rs
@@ -24,6 +24,7 @@ use polkadot_introspector_essentials::{
 	types::{AccountId32, BlockNumber, SubxtHrmpChannel, Timestamp, H256},
 };
 use std::{
+	collections::HashMap,
 	fmt::{self, Display, Formatter, Write},
 	time::Duration,
 };
@@ -137,7 +138,7 @@ pub struct ParachainProgressUpdate {
 	/// Relay chain block hash.
 	pub block_hash: H256,
 	/// Core occupation.
-	pub core_occupied: bool,
+	pub core_occupied: HashMap<u32, bool>,
 	/// Consensus events happening for the para under a relay parent.
 	pub events: Vec<ParachainConsensusEvent>,
 	/// If we are in the fork chain, then this flag will be `true`

--- a/parachain-tracer/src/utils.rs
+++ b/parachain-tracer/src/utils.rs
@@ -244,10 +244,7 @@ mod test_extract_availability_bits_count {
 	#[test]
 	fn test_counts_availability_bits() {
 		assert_eq!(
-			extract_availability_bits_count(
-				&vec![AvailabilityBitfield(DecodedBits::from_iter([true, false, true]))],
-				0
-			),
+			extract_availability_bits_count(&[AvailabilityBitfield(DecodedBits::from_iter([true, false, true]))], 0),
 			1
 		);
 	}

--- a/parachain-tracer/src/utils.rs
+++ b/parachain-tracer/src/utils.rs
@@ -229,7 +229,7 @@ mod test_extract_votes {
 	}
 }
 
-pub(crate) fn extract_availability_bits_count(bitfields: &Vec<AvailabilityBitfield>, core: u32) -> u32 {
+pub(crate) fn extract_availability_bits_count(bitfields: &[AvailabilityBitfield], core: u32) -> u32 {
 	bitfields
 		.iter()
 		.map(|v| v.0.as_bits().get(core as usize).expect("core index must be in the bitfield") as u32)

--- a/parachain-tracer/src/utils.rs
+++ b/parachain-tracer/src/utils.rs
@@ -150,13 +150,13 @@ mod test_extract_inherent_fields {
 	}
 }
 
-pub(crate) fn backed_candidate(
+pub(crate) fn backed_candidates_by_para_id(
 	backed_candidates: Vec<BackedCandidate<H256>>,
 	para_id: u32,
-) -> Option<BackedCandidate<H256>> {
+) -> impl Iterator<Item = BackedCandidate<H256>> {
 	backed_candidates
 		.into_iter()
-		.find(|candidate| candidate.candidate.descriptor.para_id.0 == para_id)
+		.filter(move |candidate| candidate.candidate.descriptor.para_id.0 == para_id)
 }
 
 #[cfg(test)]
@@ -166,9 +166,12 @@ mod test_backed_candidate {
 
 	#[test]
 	fn test_returns_a_candidate() {
-		let found = backed_candidate(vec![create_backed_candidate(100), create_backed_candidate(200)], 100).unwrap();
+		let found_candidates =
+			backed_candidates_by_para_id(vec![create_backed_candidate(100), create_backed_candidate(200)], 100);
 
-		assert_eq!(found.candidate.descriptor.para_id.0, 100);
+		for found in found_candidates {
+			assert_eq!(found.candidate.descriptor.para_id.0, 100);
+		}
 	}
 }
 
@@ -226,7 +229,7 @@ mod test_extract_votes {
 	}
 }
 
-pub(crate) fn extract_availability_bits_count(bitfields: Vec<AvailabilityBitfield>, core: u32) -> u32 {
+pub(crate) fn extract_availability_bits_count(bitfields: &Vec<AvailabilityBitfield>, core: u32) -> u32 {
 	bitfields
 		.iter()
 		.map(|v| v.0.as_bits().get(core as usize).expect("core index must be in the bitfield") as u32)
@@ -241,7 +244,10 @@ mod test_extract_availability_bits_count {
 	#[test]
 	fn test_counts_availability_bits() {
 		assert_eq!(
-			extract_availability_bits_count(vec![AvailabilityBitfield(DecodedBits::from_iter([true, false, true]))], 0),
+			extract_availability_bits_count(
+				&vec![AvailabilityBitfield(DecodedBits::from_iter([true, false, true]))],
+				0
+			),
 			1
 		);
 	}


### PR DESCRIPTION
Fixes https://github.com/paritytech/polkadot-introspector/issues/673

Major changes
- Instead of a single current candidate, we track [included, backed] candidates for each assigned core.
- We set the `included` status based on chain events, which we store in the collector.
- Dead code removed