### PR TITLE
Revert "Bump async-channel from 1.9.0 to 2.1.1"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2538,7 +2538,7 @@ dependencies = [
 name = "polkadot-introspector-priority-channel"
 version = "0.2.23"
 dependencies = [
- "async-channel 2.1.1",
+ "async-channel 1.9.0",
  "futures",
  "rand",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/paritytech/polkadot-introspector"
 
 [workspace.dependencies]
-async-channel = "2.1.1"
+async-channel = "1.9.0"
 async-trait = "0.1.77"
 bincode = "1.3.3"
 clap = { version = "4.5.1", features = ["derive"] }


### PR DESCRIPTION
This reverts commit ff6dce128d3d93c26d76dd076a5b94ff27e229d0.