### PR TITLE
Track dropped candidates

### DIFF
--- a/parachain-tracer/src/parachain_block_info.rs
+++ b/parachain-tracer/src/parachain_block_info.rs
@@ -56,12 +56,20 @@ impl ParachainBlockInfo {
 		self.state = ParachainBlockState::Included
 	}
 
+	pub fn set_dropped(&mut self) {
+		self.state = ParachainBlockState::Dropped
+	}
+
 	pub fn is_backed(&self) -> bool {
 		self.state == ParachainBlockState::Backed
 	}
 
 	pub fn is_included(&self) -> bool {
 		self.state == ParachainBlockState::Included
+	}
+
+	pub fn is_dropped(&self) -> bool {
+		self.state == ParachainBlockState::Dropped
 	}
 
 	pub fn is_bitfield_propagation_slow(&self) -> bool {
@@ -79,6 +87,8 @@ pub enum ParachainBlockState {
 	PendingAvailability,
 	// A candidate has been included.
 	Included,
+	// A candidate has been dropped after session change or availability timeout
+	Dropped,
 }
 
 #[cfg(test)]

--- a/parachain-tracer/src/types.rs
+++ b/parachain-tracer/src/types.rs
@@ -109,10 +109,14 @@ pub enum ParachainConsensusEvent {
 	Backed(H256),
 	/// A candidate was included, including availability bits
 	Included(H256, u32, u32),
+	/// A candidate was dropped.
+	Dropped(H256),
 	/// A dispute has concluded.
 	Disputed(DisputesTracker),
 	/// No candidate backed.
 	SkippedSlot,
+	/// Candidate is still not included
+	PendingAvailability(H256),
 	/// Candidate not available yet, including availability bits
 	SlowAvailability(u32, u32),
 	/// Inherent bitfield count is lower than 2/3 of expect.
@@ -195,10 +199,18 @@ impl Display for ParachainConsensusEvent {
 				writeln!(f, "\t- {}", "CANDIDATE BACKED".to_string().bold().green())?;
 				writeln!(f, "\t  💜 Candidate hash: {} ", format!("{:?}", candidate_hash).magenta())
 			},
+			ParachainConsensusEvent::PendingAvailability(candidate_hash) => {
+				writeln!(f, "\t- {}", "CANDIDATE PENDING AVAILABILITY".to_string().bold().green())?;
+				writeln!(f, "\t  💜 Candidate hash: {} ", format!("{:?}", candidate_hash).magenta())
+			},
 			ParachainConsensusEvent::Included(candidate_hash, bits_available, max_bits) => {
 				writeln!(f, "\t- {}", "CANDIDATE INCLUDED".to_string().bold().green())?;
 				writeln!(f, "\t  💜 Candidate hash: {} ", format!("{:?}", candidate_hash).magenta())?;
 				writeln!(f, "\t  🟢 Availability bits: {}/{}", bits_available, max_bits)
+			},
+			ParachainConsensusEvent::Dropped(candidate_hash) => {
+				writeln!(f, "\t- {}", "CANDIDATE DROPPED".to_string().bold().green())?;
+				writeln!(f, "\t  💜 Candidate hash: {} ", format!("{:?}", candidate_hash).magenta())
 			},
 			ParachainConsensusEvent::Disputed(outcome) => {
 				writeln!(f, "\t- {}", "💔 Dispute tracked:".to_string().bold())?;


### PR DESCRIPTION
After we change our method of candidate tracking, we faced a bug with increased backing counts. Was found that we don't remove from tracker candidates that were dropped on session change. 

This PR fixes state pruning for dropped candidates. These candidates are visible only in CLI mode, nothing goes to Prometheus. Also added visual only event for candidates pending availability. 