### PR TITLE
Show proper metrics for disputes

### DIFF
--- a/parachain-tracer/src/prometheus.rs
+++ b/parachain-tracer/src/prometheus.rs
@@ -40,9 +40,10 @@ pub struct ParachainTracerPrometheusOptions {
 struct DisputesMetrics {
 	/// Number of candidates disputed.
 	disputed_count: IntCounterVec,
+	/// Average count of validators that voted in favor of supermajority
 	concluded_valid: IntCounterVec,
-	concluded_invalid: IntCounterVec,
 	/// Average count of validators that voted against supermajority
+	concluded_invalid: IntCounterVec,
 	/// Average resolution time in blocks
 	resolution_time: HistogramVec,
 }
@@ -179,10 +180,21 @@ impl PrometheusMetrics for Metrics {
 		}
 	}
 
+	// Sets metrics to 0 at the beginning to show proper charts in Prometheus
 	fn init_disputes(&self, para_id: u32) {
 		if let Some(metrics) = &self.0 {
 			let para_string = para_id.to_string();
 			metrics.disputes_stats.disputed_count.with_label_values(&[&para_string]).reset();
+			metrics
+				.disputes_stats
+				.concluded_valid
+				.with_label_values(&[&para_string])
+				.reset();
+			metrics
+				.disputes_stats
+				.concluded_invalid
+				.with_label_values(&[&para_string])
+				.reset();
 		}
 	}
 


### PR DESCRIPTION
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/fe9be807-d8e4-4bb1-a218-19418f22987f">
We have already set disputes to zero at initialization. Here, we do the same for valid and invalid votes. Otherwise it shows no data. 