### PR TITLE
Fix relay chain block time metrics

### DIFF
--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -768,7 +768,8 @@ mod test_inject_block {
 		let current = tracker.current_relay_block.unwrap();
 		assert!(tracker.previous_relay_block.is_none());
 		assert_eq!(current.hash, first_hash);
-		assert_eq!(tracker.last_non_fork_relay_block_ts, Some(1_u64));
+		assert_eq!(tracker.current_non_fork_relay_block_ts, Some(1_u64));
+		assert_eq!(tracker.last_non_fork_relay_block_ts, None);
 		assert!(tracker.finality_lag.is_none());
 
 		// Inject a fork and relevant finalized block number
@@ -798,7 +799,8 @@ mod test_inject_block {
 		let current = tracker.current_relay_block.unwrap();
 		assert_eq!(previous.hash, first_hash);
 		assert_eq!(current.hash, second_hash);
-		assert_eq!(tracker.last_non_fork_relay_block_ts, Some(1));
+		assert_eq!(tracker.current_non_fork_relay_block_ts, Some(1));
+		assert_eq!(tracker.last_non_fork_relay_block_ts, None);
 		assert_eq!(tracker.finality_lag, Some(2));
 	}
 


### PR DESCRIPTION
Relay chain block time was always 0 because `current_relay_block.ts` was always equal to `last_non_fork_relay_block_ts`. Fixed adding temporary value for `current_non_fork_relay_block_ts`