### PR TITLE
Whois: allow querying of sessions beyond the 6 limit

### DIFF
--- a/essentials/src/api/api_client.rs
+++ b/essentials/src/api/api_client.rs
@@ -229,9 +229,18 @@ impl<T: OnlineClientT<PolkadotConfig>> ApiClient<T> {
 		self.storage().at_latest().await?.fetch(&addr).await
 	}
 
-	pub async fn get_session_account_keys(&self, session_index: u32) -> Result<Option<Vec<AccountId32>>, subxt::Error> {
+	pub async fn get_session_account_keys(
+		&self,
+		session_index: u32,
+		maybe_hash: Option<H256>,
+	) -> Result<Option<Vec<AccountId32>>, subxt::Error> {
 		let addr = polkadot::storage().para_session_info().account_keys(session_index);
-		self.storage().at_latest().await?.fetch(&addr).await
+
+		// Query session keys at a specific block hash.
+		let storage =
+			if let Some(hash) = maybe_hash { self.storage().at(hash) } else { self.storage().at_latest().await? };
+
+		storage.fetch(&addr).await
 	}
 
 	pub async fn get_session_next_keys(&self, account: &AccountId32) -> Result<Option<SessionKeys>, subxt::Error> {

--- a/essentials/src/api/executor.rs
+++ b/essentials/src/api/executor.rs
@@ -60,7 +60,7 @@ pub enum Request {
 	GetOccupiedCores(H256),
 	GetBackingGroups(H256),
 	GetSessionIndex(H256),
-	GetSessionAccountKeys(u32),
+	GetSessionAccountKeys(u32, Option<H256>),
 	GetSessionNextKeys(AccountId32),
 	GetSessionQueuedKeys(Option<H256>),
 	GetInboundOutBoundHrmpChannels(H256, Vec<u32>),
@@ -233,8 +233,8 @@ impl RequestExecutorBackend {
 				BackingGroups(decode_validator_groups(&value)?)
 			},
 			GetSessionIndex(hash) => SessionIndex(client.get_session_index(hash).await?.unwrap_or_default()),
-			GetSessionAccountKeys(session_index) =>
-				SessionAccountKeys(client.get_session_account_keys(session_index).await?),
+			GetSessionAccountKeys(session_index, maybe_hash) =>
+				SessionAccountKeys(client.get_session_account_keys(session_index, maybe_hash).await?),
 			GetSessionNextKeys(ref account) => SessionNextKeys(client.get_session_next_keys(account).await?),
 			GetSessionQueuedKeys(at) => SessionQueuedKeys(client.get_session_queued_keys(at).await?),
 			GetSessionIndexNow => SessionIndex(client.get_session_index_now().await?.unwrap_or_default()),
@@ -431,8 +431,9 @@ impl RequestExecutor {
 		&mut self,
 		url: &str,
 		session_index: u32,
+		maybe_hash: Option<H256>,
 	) -> color_eyre::Result<Option<Vec<AccountId32>>, RequestExecutorError> {
-		wrap_backend_call!(self, url, GetSessionAccountKeys, SessionAccountKeys, session_index)
+		wrap_backend_call!(self, url, GetSessionAccountKeys, SessionAccountKeys, session_index, maybe_hash)
 	}
 
 	pub async fn get_session_next_keys(

--- a/essentials/src/collector/mod.rs
+++ b/essentials/src/collector/mod.rs
@@ -608,7 +608,7 @@ impl Collector {
 			debug!("new session: {}, hash: {}", cur_session, cur_session_hash);
 			let accounts_keys = self
 				.executor
-				.get_session_account_keys(self.endpoint.as_str(), cur_session)
+				.get_session_account_keys(self.endpoint.as_str(), cur_session, None)
 				.await?
 				.ok_or_else(|| eyre!("Missing account keys for session {}", cur_session))?;
 			self.storage_write_prefixed(

--- a/whois/README.md
+++ b/whois/README.md
@@ -13,7 +13,10 @@ validator_index=<INDEX<>>, account=<ACCOUNT>, peer_id=<PEER_ID>, authorithy_id_d
 
 It uses the subp2p-explorer for querying the DHT information about each validator in the network.
 
-## Usage:
+## Usage
+
+Important: If querying more than 6 sessions behind the current one, you need to specify `--at-block` and
+provide a block hash. The block needs to be at most 6 sessions away from the query `--session-index` .
 
 ### Query by validator index
 ```


### PR DESCRIPTION
Use `at-block` to query account key storage older than 6sessions.