### PR TITLE
[WIP] Refactor apps execution

### DIFF
--- a/block-time/src/main.rs
+++ b/block-time/src/main.rs
@@ -372,20 +372,42 @@ fn register_metric(registry: &Registry) -> HistogramVec {
 async fn main() -> color_eyre::Result<()> {
 	let opts = BlockTimeOptions::parse();
 	init::init_cli(&opts.verbose)?;
+	let mut retry = utils::Retry::new(&opts.retry);
 
-	let shutdown_tx = init::init_shutdown();
-	let executor = RequestExecutor::build(opts.nodes.clone(), ApiClientMode::RPC, &opts.retry, &shutdown_tx).await?;
-	let monitor = BlockTimeMonitor::new(opts.clone(), executor.clone())?;
-	let shutdown_tx = init::init_shutdown();
-	let mut futures = vec![];
+	loop {
+		let (run_context, mut outcome_rx) = init::init_run_context();
+		let shutdown_listener = init::spawn_shutdown_listener(run_context.clone());
+		let mut executor = tokio::select! {
+			result = RequestExecutor::build(opts.nodes.clone(), ApiClientMode::RPC, &opts.retry, &run_context) => result,
+			maybe_outcome = outcome_rx.recv() => {
+				let Some(outcome) = maybe_outcome else {
+					log::error!("All RunContext senders dropped without signaling an outcome");
+					shutdown_listener.abort();
+					break;
+				};
+				shutdown_listener.abort();
+				if outcome.is_restart_requested() && retry.sleep().await.is_ok() {
+					continue;
+				}
+				break;
+			}
+		}?;
+		let monitor = BlockTimeMonitor::new(opts.clone(), executor.clone())?;
+		let mut futures = vec![];
 
-	let mut sub = ChainHeadSubscription::new(opts.nodes.clone(), executor);
-	let consumer_init = sub.create_consumer();
+		let mut sub = ChainHeadSubscription::new(opts.nodes.clone(), executor.clone());
+		let consumer_init = sub.create_consumer();
 
-	futures.extend(monitor.run(consumer_init).await?);
-	futures.extend(sub.run(&shutdown_tx).await?);
+		futures.extend(monitor.run(consumer_init).await?);
+		futures.extend(sub.run(&run_context).await?);
 
-	init::run(futures, &shutdown_tx).await?;
+		let outcome = init::run_supervised(futures, shutdown_listener, &mut outcome_rx).await?;
+		executor.close().await;
+
+		if !outcome.is_restart_requested() || retry.sleep().await.is_err() {
+			break;
+		}
+	}
 
 	Ok(())
 }

--- a/block-time/src/main.rs
+++ b/block-time/src/main.rs
@@ -377,7 +377,7 @@ async fn main() -> color_eyre::Result<()> {
 	loop {
 		let (run_context, mut outcome_rx) = init::init_run_context();
 		let shutdown_listener = init::spawn_shutdown_listener(run_context.clone());
-		let mut executor = tokio::select! {
+		let mut executor = match tokio::select! {
 			result = RequestExecutor::build(opts.nodes.clone(), ApiClientMode::RPC, &opts.retry, &run_context) => result,
 			maybe_outcome = outcome_rx.recv() => {
 				let Some(outcome) = maybe_outcome else {
@@ -391,7 +391,17 @@ async fn main() -> color_eyre::Result<()> {
 				}
 				break;
 			}
-		}?;
+		} {
+			Ok(executor) => executor,
+			Err(e) => {
+				shutdown_listener.abort();
+				log::error!("Failed to build RequestExecutor: {:?}", e);
+				if retry.sleep().await.is_err() {
+					break;
+				}
+				continue;
+			},
+		};
 		let monitor = BlockTimeMonitor::new(opts.clone(), executor.clone())?;
 		let mut futures = vec![];
 

--- a/block-time/src/main.rs
+++ b/block-time/src/main.rs
@@ -379,16 +379,9 @@ async fn main() -> color_eyre::Result<()> {
 		let shutdown_listener = init::spawn_shutdown_listener(run_context.clone());
 		let mut executor = match tokio::select! {
 			result = RequestExecutor::build(opts.nodes.clone(), ApiClientMode::RPC, &opts.retry, &run_context) => result,
-			maybe_outcome = outcome_rx.recv() => {
-				let Some(outcome) = maybe_outcome else {
-					log::error!("All RunContext senders dropped without signaling an outcome");
-					shutdown_listener.abort();
-					break;
-				};
+			Some(outcome) = outcome_rx.recv() => {
 				shutdown_listener.abort();
-				if outcome.is_restart_requested() && retry.sleep().await.is_ok() {
-					continue;
-				}
+				if outcome.is_restart_requested() && retry.sleep().await.is_ok() { continue; }
 				break;
 			}
 		} {

--- a/block-time/src/main.rs
+++ b/block-time/src/main.rs
@@ -372,45 +372,22 @@ fn register_metric(registry: &Registry) -> HistogramVec {
 async fn main() -> color_eyre::Result<()> {
 	let opts = BlockTimeOptions::parse();
 	init::init_cli(&opts.verbose)?;
-	let mut retry = utils::Retry::new(&opts.retry);
 
-	loop {
-		let (run_context, mut outcome_rx) = init::init_run_context();
-		let shutdown_listener = init::spawn_shutdown_listener(run_context.clone());
-		let mut executor = match tokio::select! {
-			result = RequestExecutor::build(opts.nodes.clone(), ApiClientMode::RPC, &opts.retry, &run_context) => result,
-			Some(outcome) = outcome_rx.recv() => {
-				shutdown_listener.abort();
-				if outcome.is_restart_requested() && retry.sleep().await.is_ok() { continue; }
-				break;
-			}
-		} {
-			Ok(executor) => executor,
-			Err(e) => {
-				shutdown_listener.abort();
-				log::error!("Failed to build RequestExecutor: {:?}", e);
-				if retry.sleep().await.is_err() {
-					break;
-				}
-				continue;
-			},
-		};
-		let monitor = BlockTimeMonitor::new(opts.clone(), executor.clone())?;
-		let mut futures = vec![];
+	let (run_context, mut outcome_rx) = init::init_run_context();
+	let shutdown_listener = init::spawn_shutdown_listener(run_context.clone());
+	let mut executor =
+		RequestExecutor::build(opts.nodes.clone(), ApiClientMode::RPC, &opts.retry, &run_context).await?;
+	let monitor = BlockTimeMonitor::new(opts.clone(), executor.clone())?;
+	let mut futures = vec![];
 
-		let mut sub = ChainHeadSubscription::new(opts.nodes.clone(), executor.clone());
-		let consumer_init = sub.create_consumer();
+	let mut sub = ChainHeadSubscription::new(opts.nodes.clone(), executor.clone());
+	let consumer_init = sub.create_consumer();
 
-		futures.extend(monitor.run(consumer_init).await?);
-		futures.extend(sub.run(&run_context).await?);
+	futures.extend(monitor.run(consumer_init).await?);
+	futures.extend(sub.run(&run_context).await?);
 
-		let outcome = init::run_supervised(futures, shutdown_listener, &mut outcome_rx).await?;
-		executor.close().await;
-
-		if !outcome.is_restart_requested() || retry.sleep().await.is_err() {
-			break;
-		}
-	}
+	init::run_supervised(futures, shutdown_listener, &mut outcome_rx).await?;
+	executor.close().await;
 
 	Ok(())
 }

--- a/essentials/src/api/executor.rs
+++ b/essentials/src/api/executor.rs
@@ -20,7 +20,7 @@ use crate::{
 		dynamic::{self, DynamicHostConfiguration, decode_validator_groups, fetch_dynamic_storage},
 	},
 	constants::MAX_MSG_QUEUE_SIZE,
-	init::Shutdown,
+	init::RunContext,
 	metadata::{
 		polkadot::{
 			runtime_apis::babe_api::types::generate_key_ownership_proof::Slot,
@@ -44,10 +44,7 @@ use polkadot_introspector_priority_channel::{
 use std::collections::{BTreeMap, HashMap, HashSet};
 use subxt::{OnlineClient, PolkadotConfig};
 use thiserror::Error;
-use tokio::sync::{
-	broadcast::Sender as BroadcastSender,
-	oneshot::{Sender as OneshotSender, error::RecvError as OneshotRecvError},
-};
+use tokio::sync::oneshot::{Sender as OneshotSender, error::RecvError as OneshotRecvError};
 
 enum ExecutorMessage {
 	Close,
@@ -179,9 +176,7 @@ impl RequestExecutorBackend {
 		url: String,
 		api_client_mode: ApiClientMode,
 	) -> color_eyre::Result<Self, RequestExecutorError> {
-		let client = build_client(&url, api_client_mode, &retry)
-			.await
-			.ok_or(RequestExecutorError::ClientBuildFailed(url))?;
+		let client = build_client(&url, api_client_mode).await?;
 
 		Ok(RequestExecutorBackend { client, retry })
 	}
@@ -354,18 +349,18 @@ impl RequestExecutor {
 		nodes: impl RequestExecutorNodes,
 		api_client_mode: ApiClientMode,
 		retry: &RetryOptions,
-		shutdown_tx: &BroadcastSender<Shutdown>,
+		run_context: &RunContext,
 	) -> color_eyre::Result<RequestExecutor, RequestExecutorError> {
 		let mut clients = HashMap::new();
 		for node in nodes.unique_nodes() {
 			let (to_backend, from_frontend) = channel(MAX_MSG_QUEUE_SIZE);
 			let mut backend = RequestExecutorBackend::build(retry.clone(), node.clone(), api_client_mode).await?;
 			let _ = clients.insert(node, (to_backend, backend.hasher()));
-			let shutdown_tx = shutdown_tx.clone();
+			let run_context = run_context.clone();
 			tokio::spawn(async move {
 				if let Err(e) = backend.run(from_frontend).await {
 					error!("Request Executor Backend failed to run, closing the application: {:?}", e);
-					let _ = shutdown_tx.send(Shutdown::Restart);
+					run_context.request_restart();
 				}
 			});
 		}
@@ -572,18 +567,11 @@ impl RequestExecutor {
 async fn build_client(
 	url: &str,
 	api_client_mode: ApiClientMode,
-	retry: &RetryOptions,
-) -> Option<ApiClient<OnlineClient<PolkadotConfig>>> {
-	let mut retry = Retry::new(retry);
-	loop {
-		match build_online_client(url, api_client_mode).await {
-			Ok(client) => return Some(client),
-			Err(err) => {
-				error!("[{}] RpcClient error: {:?}", url, err);
-				if (retry.sleep().await).is_err() {
-					return None
-				}
-			},
-		}
-	}
+) -> Result<ApiClient<OnlineClient<PolkadotConfig>>, RequestExecutorError> {
+	build_online_client(url, api_client_mode)
+		.await
+		.map_err(|err| {
+			error!("[{}] RpcClient error: {:?}", url, err);
+			RequestExecutorError::ClientBuildFailed(url.to_owned())
+		})
 }

--- a/essentials/src/api/executor.rs
+++ b/essentials/src/api/executor.rs
@@ -568,10 +568,8 @@ async fn build_client(
 	url: &str,
 	api_client_mode: ApiClientMode,
 ) -> Result<ApiClient<OnlineClient<PolkadotConfig>>, RequestExecutorError> {
-	build_online_client(url, api_client_mode)
-		.await
-		.map_err(|err| {
-			error!("[{}] RpcClient error: {:?}", url, err);
-			RequestExecutorError::ClientBuildFailed(url.to_owned())
-		})
+	build_online_client(url, api_client_mode).await.map_err(|err| {
+		error!("[{}] RpcClient error: {:?}", url, err);
+		RequestExecutorError::ClientBuildFailed(url.to_owned())
+	})
 }

--- a/essentials/src/api/mod.rs
+++ b/essentials/src/api/mod.rs
@@ -94,8 +94,8 @@ mod tests {
 	}
 
 	async fn request_executor() -> RequestExecutor {
-		let shutdown_tx = init::init_shutdown();
-		RequestExecutor::build(rpc_node_url(), ApiClientMode::RPC, &RetryOptions::default(), &shutdown_tx)
+		let (run_context, _outcome_rx) = init::init_run_context();
+		RequestExecutor::build(rpc_node_url(), ApiClientMode::RPC, &RetryOptions::default(), &run_context)
 			.await
 			.unwrap()
 	}

--- a/essentials/src/chain_head_subscription.rs
+++ b/essentials/src/chain_head_subscription.rs
@@ -20,15 +20,12 @@ use crate::{
 	chain_subscription::ChainSubscriptionEvent,
 	constants::MAX_MSG_QUEUE_SIZE,
 	consumer::{EventConsumerInit, EventStream},
-	init::Shutdown,
+	init::RunContext,
 };
 use async_trait::async_trait;
 use log::{debug, error, info};
 use polkadot_introspector_priority_channel::{Sender, channel};
-use tokio::{
-	sync::broadcast::Sender as BroadcastSender,
-	time::{Duration, interval_at},
-};
+use tokio::time::{Duration, interval_at};
 
 pub struct ChainHeadSubscription {
 	urls: Vec<String>,
@@ -58,12 +55,9 @@ impl EventStream for ChainHeadSubscription {
 		EventConsumerInit::new(update_channels)
 	}
 
-	async fn run(
-		&self,
-		shutdown_tx: &BroadcastSender<Shutdown>,
-	) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>> {
+	async fn run(&self, run_context: &RunContext) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>> {
 		let futures = self.consumers.clone().into_iter().map(|update_channels| {
-			Self::run_per_consumer(update_channels, self.urls.clone(), shutdown_tx.clone(), &self.executor)
+			Self::run_per_consumer(update_channels, self.urls.clone(), run_context.clone(), &self.executor)
 		});
 
 		Ok(futures.flatten().collect::<Vec<_>>())
@@ -79,19 +73,19 @@ impl ChainHeadSubscription {
 	async fn run_per_node(
 		mut update_channel: Sender<ChainSubscriptionEvent>,
 		url: String, // `String` rather than `&str` because we spawn this method as an asynchronous task
-		shutdown_tx: BroadcastSender<Shutdown>,
+		run_context: RunContext,
 		mut executor: RequestExecutor,
 	) {
 		use futures::stream::{StreamExt, select};
 		use futures_util::TryStreamExt;
 
-		let mut shutdown_rx = shutdown_tx.subscribe();
+		let mut cancel_rx = run_context.subscribe_cancel();
 		let best_sub = match executor.get_best_block_subscription(&url).await {
 			Ok(v) => v.map_ok(|v| ChainSubscriptionEvent::NewBestHead((v.1.hash(), v.0))),
 			Err(e) => {
 				error!("Subscription to {} failed: {:?}", url, e);
 				let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
-				let _ = shutdown_tx.send(Shutdown::Restart);
+				run_context.request_restart();
 				return
 			},
 		};
@@ -100,7 +94,7 @@ impl ChainHeadSubscription {
 			Err(e) => {
 				error!("Subscription to {} failed: {:?}", url, e);
 				let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
-				let _ = shutdown_tx.send(Shutdown::Restart);
+				run_context.request_restart();
 				return
 			},
 		};
@@ -110,6 +104,14 @@ impl ChainHeadSubscription {
 		let mut heartbeat_periodic = interval_at(tokio::time::Instant::now() + HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL);
 
 		loop {
+			if *cancel_rx.borrow() {
+				info!("Received interrupt signal shutting down subscription");
+				if let Err(e) = update_channel.send(ChainSubscriptionEvent::Termination).await {
+					info!("Event consumer has already terminated: {:?}", e);
+				}
+				return;
+			}
+
 			tokio::select! {
 				message = sub.next() => {
 					let event = match message {
@@ -117,13 +119,13 @@ impl ChainHeadSubscription {
 						Some(Err(e)) => {
 							error!("Subscription to {} failed: {:?}", url, e);
 							let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
-							let _ = shutdown_tx.send(Shutdown::Restart);
+							run_context.request_restart();
 							return
 						},
 						None => {
 							error!("Subscription to {} failed, received None instead of an event", url);
 							let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
-							let _ = shutdown_tx.send(Shutdown::Restart);
+							run_context.request_restart();
 							return
 						}
 					};
@@ -133,7 +135,7 @@ impl ChainHeadSubscription {
 						return;
 					}
 				},
-				_ = shutdown_rx.recv() => {
+				_ = cancel_rx.changed() => {
 					info!("Received interrupt signal shutting down subscription");
 					if let Err(e) = update_channel.send(ChainSubscriptionEvent::Termination).await {
 						info!("Event consumer has already terminated: {:?}", e);
@@ -155,14 +157,14 @@ impl ChainHeadSubscription {
 	fn run_per_consumer(
 		update_channels: Vec<Sender<ChainSubscriptionEvent>>,
 		urls: Vec<String>,
-		shutdown_tx: BroadcastSender<Shutdown>,
+		run_context: RunContext,
 		executor: &RequestExecutor,
 	) -> Vec<tokio::task::JoinHandle<()>> {
 		update_channels
 			.into_iter()
 			.zip(urls)
 			.map(|(update_channel, url)| {
-				tokio::spawn(Self::run_per_node(update_channel, url, shutdown_tx.clone(), executor.clone()))
+				tokio::spawn(Self::run_per_node(update_channel, url, run_context.clone(), executor.clone()))
 			})
 			.collect()
 	}

--- a/essentials/src/collector/mod.rs
+++ b/essentials/src/collector/mod.rs
@@ -26,7 +26,6 @@ use crate::{
 		ChainEvent, SubxtCandidateEvent, SubxtCandidateEventType, SubxtDispute, SubxtDisputeResult, decode_chain_event,
 	},
 	chain_subscription::ChainSubscriptionEvent,
-	init::Shutdown,
 	metadata::{polkadot::runtime_types::sp_consensus_slots::Slot, polkadot_primitives::DisputeStatement},
 	storage::{RecordTime, RecordsStorageConfig, StorageEntry},
 	types::{AccountId32, ClaimQueue, H256, Header, InherentData, OnDemandOrder, PolkadotHasher, Timestamp},
@@ -54,7 +53,6 @@ use subxt::{
 	config::{Hasher, polkadot::U256},
 };
 use thiserror::Error;
-use tokio::sync::broadcast::Sender as BroadcastSender;
 use ws::{WebSocketEventType, WebSocketListener, WebSocketListenerConfig, WebSocketUpdateEvent};
 
 /// Used for bulk messages in the normal channels
@@ -282,11 +280,11 @@ impl Collector {
 	}
 
 	/// Spawns a collector futures (e.g. websocket server)
-	pub async fn spawn(&mut self, shutdown_tx: &BroadcastSender<Shutdown>) -> color_eyre::Result<()> {
+	pub async fn spawn(&mut self, run_context: &crate::init::RunContext) -> color_eyre::Result<()> {
 		if let Some(ws_listener) = &self.ws_listener {
 			let (to_websocket, from_collector) = priority_channel(32);
 			ws_listener
-				.spawn(shutdown_tx.subscribe(), from_collector)
+				.spawn(run_context.subscribe_shutdown(), from_collector)
 				.await
 				.map_err(|e| eyre!("Cannot spawn a listener: {:?}", e))?;
 			self.to_websocket = Some(to_websocket);

--- a/essentials/src/consumer.rs
+++ b/essentials/src/consumer.rs
@@ -16,10 +16,9 @@
 //
 //! Event consumer traits and types. Abstracts on-chain/off-chain event streams and
 //! APIs for RPC nodes and internal storage.
-use crate::init::Shutdown;
+use crate::init::RunContext;
 use async_trait::async_trait;
 use polkadot_introspector_priority_channel::Receiver;
-use tokio::sync::broadcast::Sender as BroadcastSender;
 
 #[async_trait]
 pub trait EventStream {
@@ -29,10 +28,7 @@ pub trait EventStream {
 	fn create_consumer(&mut self) -> EventConsumerInit<Self::Event>;
 
 	/// Prepare futures to join.
-	async fn run(
-		&self,
-		shutdown_tx: &BroadcastSender<Shutdown>,
-	) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>>;
+	async fn run(&self, run_context: &RunContext) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>>;
 }
 
 #[derive(Debug)]

--- a/essentials/src/historical_subscription.rs
+++ b/essentials/src/historical_subscription.rs
@@ -74,13 +74,7 @@ impl EventStream for HistoricalSubscription {
 }
 
 impl HistoricalSubscription {
-	async fn finish(update_channel: &mut Sender<ChainSubscriptionEvent>) {
-		if let Err(e) = update_channel.send(ChainSubscriptionEvent::Termination).await {
-			info!("Event consumer has already terminated: {:?}", e);
-		}
-	}
-
-	async fn terminate_on_cancel(update_channel: &mut Sender<ChainSubscriptionEvent>) {
+	async fn send_termination(update_channel: &mut Sender<ChainSubscriptionEvent>) {
 		if let Err(e) = update_channel.send(ChainSubscriptionEvent::Termination).await {
 			info!("Event consumer has already terminated: {:?}", e);
 		}
@@ -110,13 +104,13 @@ impl HistoricalSubscription {
 			result = executor.get_block_number(&url, None) => result,
 			_ = cancel_rx.changed() => {
 				info!("Received interrupt signal shutting down subscription");
-				Self::terminate_on_cancel(&mut update_channel).await;
+				Self::send_termination(&mut update_channel).await;
 				return;
 			}
 		} {
 			Ok(v) => v,
-			Err(_) => {
-				error!("Subscription to {} failed, last block not found", url);
+			Err(e) => {
+				error!("Subscription to {} failed to fetch last block: {:?}", url, e);
 				let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
 				run_context.request_restart();
 				return
@@ -137,7 +131,7 @@ impl HistoricalSubscription {
 				result = executor.get_block_hash(&url, Some(block_number)) => result,
 				_ = cancel_rx.changed() => {
 					info!("Received interrupt signal shutting down subscription");
-					Self::terminate_on_cancel(&mut update_channel).await;
+					Self::send_termination(&mut update_channel).await;
 					return;
 				}
 			} {
@@ -159,7 +153,7 @@ impl HistoricalSubscription {
 				result = executor.get_block_head(&url, Some(block_hash)) => result,
 				_ = cancel_rx.changed() => {
 					info!("Received interrupt signal shutting down subscription");
-					Self::terminate_on_cancel(&mut update_channel).await;
+					Self::send_termination(&mut update_channel).await;
 					return;
 				}
 			} {
@@ -196,13 +190,13 @@ impl HistoricalSubscription {
 
 			if *cancel_rx.borrow() {
 				info!("Received interrupt signal shutting down subscription");
-				Self::terminate_on_cancel(&mut update_channel).await;
+				Self::send_termination(&mut update_channel).await;
 				return;
 			}
 		}
 
 		info!("[{}] Historical range completed, terminating subscription", url);
-		Self::finish(&mut update_channel).await;
+		Self::send_termination(&mut update_channel).await;
 	}
 
 	// Sets up per websocket tasks to handle updates and reconnects on errors.

--- a/essentials/src/historical_subscription.rs
+++ b/essentials/src/historical_subscription.rs
@@ -27,6 +27,14 @@ use async_trait::async_trait;
 use log::{debug, error, info};
 use polkadot_introspector_priority_channel::{Sender, channel};
 
+macro_rules! send_termination {
+	($ch:expr) => {
+		if let Err(e) = $ch.send(ChainSubscriptionEvent::Termination).await {
+			info!("Event consumer has already terminated: {:?}", e);
+		}
+	};
+}
+
 pub struct HistoricalSubscription {
 	urls: Vec<String>,
 	from_block_number: BlockNumber,
@@ -74,12 +82,6 @@ impl EventStream for HistoricalSubscription {
 }
 
 impl HistoricalSubscription {
-	async fn send_termination(update_channel: &mut Sender<ChainSubscriptionEvent>) {
-		if let Err(e) = update_channel.send(ChainSubscriptionEvent::Termination).await {
-			info!("Event consumer has already terminated: {:?}", e);
-		}
-	}
-
 	pub fn new(
 		urls: Vec<String>,
 		from_block_number: BlockNumber,
@@ -92,26 +94,19 @@ impl HistoricalSubscription {
 	// Per node
 	async fn run_per_node(
 		mut update_channel: Sender<ChainSubscriptionEvent>,
-		url: String, // `String` rather than `&str` because we spawn this method as an asynchronous task
+		url: String,
 		from_block_number: BlockNumber,
 		to_block_number: BlockNumber,
 		run_context: RunContext,
 		mut executor: RequestExecutor,
 	) {
-		let mut cancel_rx = run_context.subscribe_cancel();
+		let cancel_rx = run_context.subscribe_cancel();
 
-		let last_block_number = match tokio::select! {
-			result = executor.get_block_number(&url, None) => result,
-			_ = cancel_rx.changed() => {
-				info!("Received interrupt signal shutting down subscription");
-				Self::send_termination(&mut update_channel).await;
-				return;
-			}
-		} {
+		let last_block_number = match executor.get_block_number(&url, None).await {
 			Ok(v) => v,
 			Err(e) => {
 				error!("Subscription to {} failed to fetch last block: {:?}", url, e);
-				let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
+				send_termination!(update_channel);
 				run_context.request_restart();
 				return
 			},
@@ -119,54 +114,46 @@ impl HistoricalSubscription {
 
 		if from_block_number >= last_block_number || to_block_number >= last_block_number {
 			error!("`--from` and `--to` must be less then {}", last_block_number);
-			let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
+			send_termination!(update_channel);
 			run_context.complete();
 			return
 		}
 
 		for block_number in from_block_number..=to_block_number {
+			if *cancel_rx.borrow() {
+				info!("Received interrupt signal shutting down subscription");
+				send_termination!(update_channel);
+				return;
+			}
+
 			debug!("Subscription advacing to block #{}/#{}", block_number, to_block_number);
 
-			let block_hash = match tokio::select! {
-				result = executor.get_block_hash(&url, Some(block_number)) => result,
-				_ = cancel_rx.changed() => {
-					info!("Received interrupt signal shutting down subscription");
-					Self::send_termination(&mut update_channel).await;
-					return;
-				}
-			} {
+			let block_hash = match executor.get_block_hash(&url, Some(block_number)).await {
 				Ok(Some(v)) => v,
 				Ok(None) => {
 					error!("Subscription to {} failed, block hash for block #{} not found", url, block_number);
-					let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
+					send_termination!(update_channel);
 					run_context.request_restart();
 					return
 				},
 				Err(e) => {
 					error!("Subscription to {} failed: {:?}", url, e);
-					let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
+					send_termination!(update_channel);
 					run_context.request_restart();
 					return
 				},
 			};
-			let header = match tokio::select! {
-				result = executor.get_block_head(&url, Some(block_hash)) => result,
-				_ = cancel_rx.changed() => {
-					info!("Received interrupt signal shutting down subscription");
-					Self::send_termination(&mut update_channel).await;
-					return;
-				}
-			} {
+			let header = match executor.get_block_head(&url, Some(block_hash)).await {
 				Ok(Some(v)) => v,
 				Ok(None) => {
 					error!("Subscription to {} failed, header for block #{} not found", url, block_number);
-					let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
+					send_termination!(update_channel);
 					run_context.request_restart();
 					return
 				},
 				Err(e) => {
 					error!("Subscription to {} failed: {:?}", url, e);
-					let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
+					send_termination!(update_channel);
 					run_context.request_restart();
 					return
 				},
@@ -187,16 +174,10 @@ impl HistoricalSubscription {
 				info!("Event consumer has terminated: {:?}, shutting down", e);
 				return
 			}
-
-			if *cancel_rx.borrow() {
-				info!("Received interrupt signal shutting down subscription");
-				Self::send_termination(&mut update_channel).await;
-				return;
-			}
 		}
 
 		info!("[{}] Historical range completed, terminating subscription", url);
-		Self::send_termination(&mut update_channel).await;
+		send_termination!(update_channel);
 		run_context.complete();
 	}
 

--- a/essentials/src/historical_subscription.rs
+++ b/essentials/src/historical_subscription.rs
@@ -20,16 +20,12 @@ use crate::{
 	chain_subscription::ChainSubscriptionEvent,
 	constants::MAX_MSG_QUEUE_SIZE,
 	consumer::{EventConsumerInit, EventStream},
-	init::Shutdown,
+	init::RunContext,
 	types::BlockNumber,
 };
 use async_trait::async_trait;
 use log::{debug, error, info};
 use polkadot_introspector_priority_channel::{Sender, channel};
-use tokio::{
-	sync::broadcast::{Sender as BroadcastSender, error::TryRecvError},
-	time::{Duration, interval_at},
-};
 
 pub struct HistoricalSubscription {
 	urls: Vec<String>,
@@ -61,17 +57,14 @@ impl EventStream for HistoricalSubscription {
 		EventConsumerInit::new(update_channels)
 	}
 
-	async fn run(
-		&self,
-		shutdown_tx: &BroadcastSender<Shutdown>,
-	) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>> {
+	async fn run(&self, run_context: &RunContext) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>> {
 		let futures = self.consumers.clone().into_iter().map(|update_channels| {
 			Self::run_per_consumer(
 				update_channels,
 				self.urls.clone(),
 				self.from_block_number,
 				self.to_block_number,
-				shutdown_tx.clone(),
+				run_context.clone(),
 				&self.executor,
 			)
 		});
@@ -81,6 +74,18 @@ impl EventStream for HistoricalSubscription {
 }
 
 impl HistoricalSubscription {
+	async fn finish(update_channel: &mut Sender<ChainSubscriptionEvent>) {
+		if let Err(e) = update_channel.send(ChainSubscriptionEvent::Termination).await {
+			info!("Event consumer has already terminated: {:?}", e);
+		}
+	}
+
+	async fn terminate_on_cancel(update_channel: &mut Sender<ChainSubscriptionEvent>) {
+		if let Err(e) = update_channel.send(ChainSubscriptionEvent::Termination).await {
+			info!("Event consumer has already terminated: {:?}", e);
+		}
+	}
+
 	pub fn new(
 		urls: Vec<String>,
 		from_block_number: BlockNumber,
@@ -96,52 +101,79 @@ impl HistoricalSubscription {
 		url: String, // `String` rather than `&str` because we spawn this method as an asynchronous task
 		from_block_number: BlockNumber,
 		to_block_number: BlockNumber,
-		shutdown_tx: BroadcastSender<Shutdown>,
+		run_context: RunContext,
 		mut executor: RequestExecutor,
 	) {
-		let mut shutdown_rx = shutdown_tx.subscribe();
-		const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(1000);
-		let mut heartbeat_periodic = interval_at(tokio::time::Instant::now() + HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL);
+		let mut cancel_rx = run_context.subscribe_cancel();
 
-		let last_block_number = match executor.get_block_number(&url, None).await {
+		let last_block_number = match tokio::select! {
+			result = executor.get_block_number(&url, None) => result,
+			_ = cancel_rx.changed() => {
+				info!("Received interrupt signal shutting down subscription");
+				Self::terminate_on_cancel(&mut update_channel).await;
+				return;
+			}
+		} {
 			Ok(v) => v,
 			Err(_) => {
 				error!("Subscription to {} failed, last block not found", url);
+				let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
+				run_context.request_restart();
 				return
 			},
 		};
 
 		if from_block_number >= last_block_number || to_block_number >= last_block_number {
 			error!("`--from` and `--to` must be less then {}", last_block_number);
+			let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
+			run_context.complete();
 			return
 		}
 
 		for block_number in from_block_number..=to_block_number {
 			debug!("Subscription advacing to block #{}/#{}", block_number, to_block_number);
 
-			let block_hash = match executor.get_block_hash(&url, Some(block_number)).await {
+			let block_hash = match tokio::select! {
+				result = executor.get_block_hash(&url, Some(block_number)) => result,
+				_ = cancel_rx.changed() => {
+					info!("Received interrupt signal shutting down subscription");
+					Self::terminate_on_cancel(&mut update_channel).await;
+					return;
+				}
+			} {
 				Ok(Some(v)) => v,
 				Ok(None) => {
 					error!("Subscription to {} failed, block hash for block #{} not found", url, block_number);
-					let _ = shutdown_tx.send(Shutdown::Restart);
+					let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
+					run_context.request_restart();
 					return
 				},
 				Err(e) => {
 					error!("Subscription to {} failed: {:?}", url, e);
-					let _ = shutdown_tx.send(Shutdown::Restart);
+					let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
+					run_context.request_restart();
 					return
 				},
 			};
-			let header = match executor.get_block_head(&url, Some(block_hash)).await {
+			let header = match tokio::select! {
+				result = executor.get_block_head(&url, Some(block_hash)) => result,
+				_ = cancel_rx.changed() => {
+					info!("Received interrupt signal shutting down subscription");
+					Self::terminate_on_cancel(&mut update_channel).await;
+					return;
+				}
+			} {
 				Ok(Some(v)) => v,
 				Ok(None) => {
 					error!("Subscription to {} failed, header for block #{} not found", url, block_number);
-					let _ = shutdown_tx.send(Shutdown::Restart);
+					let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
+					run_context.request_restart();
 					return
 				},
 				Err(e) => {
 					error!("Subscription to {} failed: {:?}", url, e);
-					let _ = shutdown_tx.send(Shutdown::Restart);
+					let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
+					run_context.request_restart();
 					return
 				},
 			};
@@ -162,33 +194,15 @@ impl HistoricalSubscription {
 				return
 			}
 
-			match shutdown_rx.try_recv() {
-				Err(TryRecvError::Closed) | Ok(_) => {
-					info!("Received interrupt signal shutting down subscription");
-					return
-				},
-				_ => {},
+			if *cancel_rx.borrow() {
+				info!("Received interrupt signal shutting down subscription");
+				Self::terminate_on_cancel(&mut update_channel).await;
+				return;
 			}
 		}
 
-		loop {
-			// We wait here for termination.
-			tokio::select! {
-				_ = shutdown_rx.recv() => {
-					info!("Received interrupt signal shutting down subscription");
-					return;
-				}
-				_ = heartbeat_periodic.tick() => {
-					debug!("sent heartbeat to subscribers");
-					let res = update_channel.send(ChainSubscriptionEvent::Heartbeat).await;
-					if let Err(e) = res {
-						info!("Event consumer has terminated: {:?}, shutting down", e);
-						return;
-					}
-					heartbeat_periodic = interval_at(tokio::time::Instant::now() + HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL);
-				}
-			}
-		}
+		info!("[{}] Historical range completed, terminating subscription", url);
+		Self::finish(&mut update_channel).await;
 	}
 
 	// Sets up per websocket tasks to handle updates and reconnects on errors.
@@ -197,7 +211,7 @@ impl HistoricalSubscription {
 		urls: Vec<String>,
 		from_block_number: BlockNumber,
 		to_block_number: BlockNumber,
-		shutdown_tx: BroadcastSender<Shutdown>,
+		run_context: RunContext,
 		executor: &RequestExecutor,
 	) -> Vec<tokio::task::JoinHandle<()>> {
 		update_channels
@@ -209,7 +223,7 @@ impl HistoricalSubscription {
 					url,
 					from_block_number,
 					to_block_number,
-					shutdown_tx.clone(),
+					run_context.clone(),
 					executor.clone(),
 				))
 			})

--- a/essentials/src/historical_subscription.rs
+++ b/essentials/src/historical_subscription.rs
@@ -197,6 +197,7 @@ impl HistoricalSubscription {
 
 		info!("[{}] Historical range completed, terminating subscription", url);
 		Self::send_termination(&mut update_channel).await;
+		run_context.complete();
 	}
 
 	// Sets up per websocket tasks to handle updates and reconnects on errors.

--- a/essentials/src/init.rs
+++ b/essentials/src/init.rs
@@ -123,7 +123,7 @@ pub async fn on_shutdown(run_context: RunContext) {
 		Ok(()) => run_context.request_cancel(),
 		Err(e) => {
 			error!("Failed to listen for shutdown signal: {:?}", e);
-			futures::future::pending::<()>().await;
+			run_context.request_cancel();
 		},
 	}
 }

--- a/essentials/src/init.rs
+++ b/essentials/src/init.rs
@@ -151,7 +151,7 @@ pub async fn run_supervised(
 				Err(e) if e.is_cancelled() => {},
 				Err(e) => return Err(e.into()),
 			}
-			return Ok(RunOutcome::Completed);
+			return Ok(outcome_rx.try_recv().unwrap_or(RunOutcome::Completed));
 		},
 		maybe_outcome = outcome_rx.recv() => {
 			match maybe_outcome {

--- a/essentials/src/init.rs
+++ b/essentials/src/init.rs
@@ -1,9 +1,18 @@
 use clap::{ArgAction, Args};
 use futures::future;
-use log::LevelFilter;
+use log::{LevelFilter, error, warn};
+use std::sync::{
+	Arc,
+	atomic::{AtomicBool, Ordering},
+};
 use tokio::{
 	signal,
-	sync::broadcast::{self, Sender as BroadcastSender},
+	sync::{
+		broadcast::{self, Receiver as BroadcastReceiver, Sender as BroadcastSender},
+		mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
+		watch,
+	},
+	task::JoinHandle,
 };
 
 #[derive(Clone, Debug, Args)]
@@ -13,10 +22,74 @@ pub struct VerbosityOptions {
 	pub verbose: u8,
 }
 
-#[derive(Clone, Copy, Debug)]
-pub enum Shutdown {
-	Graceful,
-	Restart,
+/// Outcome of a supervised run: normal completion, restart, or cancellation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RunOutcome {
+	Completed,
+	RestartRequested,
+	Cancelled,
+}
+
+impl RunOutcome {
+	/// Returns `true` if the outcome is a restart request.
+	pub fn is_restart_requested(&self) -> bool {
+		matches!(self, RunOutcome::RestartRequested)
+	}
+}
+
+/// Shared handle for coordinating cancellation and lifecycle outcomes across tasks.
+#[derive(Clone)]
+pub struct RunContext {
+	cancel_tx: watch::Sender<bool>,
+	shutdown_tx: BroadcastSender<()>,
+	outcome_tx: UnboundedSender<RunOutcome>,
+	outcome_sent: Arc<AtomicBool>,
+}
+
+impl RunContext {
+	/// Returns a watch receiver that becomes `true` when cancellation is requested.
+	pub fn subscribe_cancel(&self) -> watch::Receiver<bool> {
+		self.cancel_tx.subscribe()
+	}
+
+	/// Returns a broadcast receiver for legacy shutdown notifications (e.g. websocket listeners).
+	pub fn subscribe_shutdown(&self) -> BroadcastReceiver<()> {
+		self.shutdown_tx.subscribe()
+	}
+
+	fn cancel(&self) {
+		if !*self.cancel_tx.borrow() {
+			let _ = self.cancel_tx.send(true);
+			let _ = self.shutdown_tx.send(());
+		}
+	}
+
+	fn send_outcome(&self, outcome: RunOutcome) {
+		if self.outcome_sent.swap(true, Ordering::AcqRel) {
+			return;
+		}
+		if self.outcome_tx.send(outcome).is_err() {
+			warn!("Outcome receiver already dropped, {:?} may be lost", outcome);
+		}
+	}
+
+	/// Signals that work completed normally and cancels remaining tasks.
+	pub fn complete(&self) {
+		self.send_outcome(RunOutcome::Completed);
+		self.cancel();
+	}
+
+	/// Signals that a restart is needed (e.g. RPC disconnect) and cancels remaining tasks.
+	pub fn request_restart(&self) {
+		self.send_outcome(RunOutcome::RestartRequested);
+		self.cancel();
+	}
+
+	/// Signals user-initiated cancellation (e.g. ctrl+c) and cancels remaining tasks.
+	pub fn request_cancel(&self) {
+		self.send_outcome(RunOutcome::Cancelled);
+		self.cancel();
+	}
 }
 
 pub fn init_cli(opts: &VerbosityOptions) -> color_eyre::Result<()> {
@@ -35,26 +108,66 @@ pub fn init_cli(opts: &VerbosityOptions) -> color_eyre::Result<()> {
 	Ok(())
 }
 
-pub fn init_shutdown() -> BroadcastSender<Shutdown> {
-	broadcast::channel(10).0
+/// Creates a fresh `RunContext` and its paired outcome receiver.
+pub fn init_run_context() -> (RunContext, UnboundedReceiver<RunOutcome>) {
+	let (outcome_tx, outcome_rx) = unbounded_channel();
+	let (shutdown_tx, _) = broadcast::channel(10);
+	let (cancel_tx, _) = watch::channel(false);
+
+	(RunContext { cancel_tx, shutdown_tx, outcome_tx, outcome_sent: Arc::new(AtomicBool::new(false)) }, outcome_rx)
 }
 
-pub async fn on_shutdown(shutdown_tx: BroadcastSender<Shutdown>) {
-	let mut shutdown_rx = shutdown_tx.subscribe();
-	tokio::select! {
-		_ = signal::ctrl_c() => {
-			shutdown_tx.send(Shutdown::Graceful).unwrap();
+/// Waits for ctrl+c and requests cancellation on the given context.
+pub async fn on_shutdown(run_context: RunContext) {
+	match signal::ctrl_c().await {
+		Ok(()) => run_context.request_cancel(),
+		Err(e) => {
+			error!("Failed to listen for shutdown signal: {:?}", e);
+			futures::future::pending::<()>().await;
 		},
-		_ = shutdown_rx.recv() => {}
 	}
 }
 
-pub async fn run(
-	mut futures: Vec<tokio::task::JoinHandle<()>>,
-	shutdown_tx: &BroadcastSender<Shutdown>,
-) -> color_eyre::Result<()> {
-	futures.push(tokio::spawn(on_shutdown(shutdown_tx.clone())));
-	future::try_join_all(futures).await?;
+/// Spawns a background task that listens for ctrl+c and triggers cancellation.
+pub fn spawn_shutdown_listener(run_context: RunContext) -> JoinHandle<()> {
+	tokio::spawn(on_shutdown(run_context))
+}
 
-	Ok(())
+/// Runs worker futures until an outcome is signaled, then aborts remaining workers.
+pub async fn run_supervised(
+	futures: Vec<tokio::task::JoinHandle<()>>,
+	shutdown_listener: JoinHandle<()>,
+	outcome_rx: &mut UnboundedReceiver<RunOutcome>,
+) -> color_eyre::Result<RunOutcome> {
+	let abort_handles: Vec<_> = futures.iter().map(|future| future.abort_handle()).collect();
+	let workers = future::try_join_all(futures);
+	tokio::pin!(workers);
+
+	let outcome = tokio::select! {
+		result = &mut workers => {
+			shutdown_listener.abort();
+			match result {
+				Ok(_) => {},
+				Err(e) if e.is_cancelled() => {},
+				Err(e) => return Err(e.into()),
+			}
+			return Ok(RunOutcome::Completed);
+		},
+		maybe_outcome = outcome_rx.recv() => {
+			match maybe_outcome {
+				Some(outcome) => outcome,
+				None => {
+					error!("All RunContext senders dropped without signaling an outcome");
+					RunOutcome::Cancelled
+				},
+			}
+		}
+	};
+
+	for handle in &abort_handles {
+		handle.abort();
+	}
+	let _ = workers.await;
+	shutdown_listener.abort();
+	Ok(outcome)
 }

--- a/essentials/src/telemetry_subscription.rs
+++ b/essentials/src/telemetry_subscription.rs
@@ -125,7 +125,11 @@ impl TelemetrySubscription {
 		let mut cancel_rx = run_context.subscribe_cancel();
 		let mut stream = match TelemetryStream::connect(&url).await {
 			Ok(v) => v,
-			Err(e) => return on_stream_error(e),
+			Err(e) => {
+				on_stream_error(e);
+				run_context.request_restart();
+				return;
+			},
 		};
 		let mut subscribed: bool = false;
 		let mut chains: HashMap<H256, AddedChain> = Default::default();
@@ -151,7 +155,9 @@ impl TelemetrySubscription {
 							chains.insert(chain.genesis_hash, chain.clone());
 						}
 						if let Err(e) = update_channel.send(TelemetryEvent::NewMessage(message)).await {
-							return on_consumer_error(e);
+							on_consumer_error(e);
+							run_context.complete();
+							return;
 						}
 					}
 
@@ -160,12 +166,16 @@ impl TelemetrySubscription {
 							Ok(hash) => {
 								if let Err(e) = stream.subscribe_to(&hash).await {
 									on_stream_error(e);
+									run_context.request_restart();
+									return;
 								} else {
 									subscribed = true;
 								}
 							},
 							Err(e) => {
-								return on_choose_chain_error(e);
+								on_choose_chain_error(e);
+								run_context.complete();
+								return;
 							}
 						}
 					}

--- a/essentials/src/telemetry_subscription.rs
+++ b/essentials/src/telemetry_subscription.rs
@@ -19,7 +19,7 @@ use super::telemetry_feed::TelemetryFeed;
 use crate::{
 	constants::MAX_MSG_QUEUE_SIZE,
 	consumer::{EventConsumerInit, EventStream},
-	init::Shutdown,
+	init::RunContext,
 	telemetry_feed::AddedChain,
 	types::H256,
 };
@@ -34,7 +34,7 @@ use std::{
 	collections::HashMap,
 	io::{BufRead, stdin},
 };
-use tokio::{net::TcpStream, sync::broadcast::Sender as BroadcastSender};
+use tokio::net::TcpStream;
 use tokio_tungstenite::{
 	MaybeTlsStream, WebSocketStream, connect_async,
 	tungstenite::{Error as WsError, Message},
@@ -93,10 +93,7 @@ impl EventStream for TelemetrySubscription {
 		EventConsumerInit::new(vec![update_rx])
 	}
 
-	async fn run(
-		&self,
-		shutdown_tx: &BroadcastSender<Shutdown>,
-	) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>> {
+	async fn run(&self, run_context: &RunContext) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>> {
 		Ok(self
 			.consumers
 			.clone()
@@ -106,7 +103,7 @@ impl EventStream for TelemetrySubscription {
 					update_channel,
 					self.url.clone(),
 					self.maybe_chain_name.clone(),
-					shutdown_tx.clone(),
+					run_context.clone(),
 				))
 			})
 			.collect::<Vec<_>>())
@@ -123,9 +120,9 @@ impl TelemetrySubscription {
 		mut update_channel: Sender<TelemetryEvent>,
 		url: String, // `String` rather than `&str` because we spawn this method as an asynchronous task
 		maybe_chain_name: Option<String>,
-		shutdown_tx: BroadcastSender<Shutdown>,
+		run_context: RunContext,
 	) {
-		let mut shutdown_rx = shutdown_tx.subscribe();
+		let mut cancel_rx = run_context.subscribe_cancel();
 		let mut stream = match TelemetryStream::connect(&url).await {
 			Ok(v) => v,
 			Err(e) => return on_stream_error(e),
@@ -173,7 +170,7 @@ impl TelemetrySubscription {
 						}
 					}
 				},
-				_ = shutdown_rx.recv() => {
+				_ = cancel_rx.changed() => {
 					return on_ctrl_c();
 				}
 			}

--- a/essentials/src/utils.rs
+++ b/essentials/src/utils.rs
@@ -87,8 +87,7 @@ impl Retry {
 			return Err(RetryError::MaxCountReached)
 		}
 
-		// Cap at 50 to prevent shift overflow panic when count >= 64
-		let exponent = self.count.min(50);
+		let exponent = self.count.min(10);
 		let ms = (self.delay as u64).saturating_mul(1u64 << exponent);
 		warn!("Retrying in {}ms...", ms);
 		tokio::select! {

--- a/essentials/src/utils.rs
+++ b/essentials/src/utils.rs
@@ -16,8 +16,8 @@
 //
 
 use clap::Parser;
-use log::warn;
-use std::time::Duration;
+use log::{info, warn};
+use std::time::{Duration, Instant};
 use thiserror::Error;
 use tokio::time::sleep;
 
@@ -33,12 +33,19 @@ pub struct RetryOptions {
 	/// Delay in ms to wait between retry attempts
 	#[clap(default_value = "100", long)]
 	retry_delay: u32,
+	/// Seconds of stable operation after which the retry counter resets.
+	/// If the last retry was longer ago than this threshold, the counter
+	/// resets to zero so a new series of failures gets the full budget.
+	#[clap(default_value = "3600", long)]
+	retry_reset_after: u64,
 }
 
 pub struct Retry {
 	count: u32,
 	max_count: u32,
 	delay: u32,
+	reset_after: Duration,
+	last_attempt: Option<Instant>,
 }
 
 #[derive(Debug, Error)]
@@ -55,10 +62,24 @@ impl Default for Retry {
 
 impl Retry {
 	pub fn new(opts: &RetryOptions) -> Self {
-		Self { count: 0, max_count: opts.max_count, delay: opts.retry_delay }
+		Self {
+			count: 0,
+			max_count: opts.max_count,
+			delay: opts.retry_delay,
+			reset_after: Duration::from_secs(opts.retry_reset_after),
+			last_attempt: None,
+		}
 	}
 
 	pub async fn sleep(&mut self) -> color_eyre::Result<(), RetryError> {
+		if let Some(last) = self.last_attempt &&
+			last.elapsed() >= self.reset_after
+		{
+			info!("Last retry was over {}s ago, resetting retry counter", self.reset_after.as_secs());
+			self.count = 0;
+		}
+		self.last_attempt = Some(Instant::now());
+
 		self.count += 1;
 		if self.count > self.max_count {
 			return Err(RetryError::MaxCountReached)

--- a/essentials/src/utils.rs
+++ b/essentials/src/utils.rs
@@ -52,6 +52,8 @@ pub struct Retry {
 pub enum RetryError {
 	#[error("Max count reached")]
 	MaxCountReached,
+	#[error("Cancelled")]
+	Cancelled,
 }
 
 impl Default for Retry {
@@ -85,11 +87,13 @@ impl Retry {
 			return Err(RetryError::MaxCountReached)
 		}
 
-		let ms = (self.delay as u64).saturating_mul(1u64 << self.count);
+		// Cap at 50 to prevent shift overflow panic when count >= 64
+		let exponent = self.count.min(50);
+		let ms = (self.delay as u64).saturating_mul(1u64 << exponent);
 		warn!("Retrying in {}ms...", ms);
 		tokio::select! {
 			_ = sleep(Duration::from_millis(ms)) => {},
-			_ = tokio::signal::ctrl_c() => return Err(RetryError::MaxCountReached),
+			_ = tokio::signal::ctrl_c() => return Err(RetryError::Cancelled),
 		}
 
 		Ok(())

--- a/essentials/src/utils.rs
+++ b/essentials/src/utils.rs
@@ -64,9 +64,12 @@ impl Retry {
 			return Err(RetryError::MaxCountReached)
 		}
 
-		let ms = self.delay * (self.count + 1);
+		let ms = (self.delay as u64).saturating_mul(1u64 << self.count);
 		warn!("Retrying in {}ms...", ms);
-		sleep(Duration::from_millis(ms.into())).await;
+		tokio::select! {
+			_ = sleep(Duration::from_millis(ms)) => {},
+			_ = tokio::signal::ctrl_c() => return Err(RetryError::MaxCountReached),
+		}
 
 		Ok(())
 	}

--- a/parachain-tracer/src/main.rs
+++ b/parachain-tracer/src/main.rs
@@ -287,15 +287,11 @@ impl ParachainTracer {
 							}
 						},
 						CollectorUpdateEvent::Termination(reason) => {
-							info!("collector is terminating");
-							match reason {
-								TerminationReason::Normal => break,
-								TerminationReason::Abnormal(info) => {
-									error!("Shutting down, {}", info);
-									run_context.request_restart();
-									break;
-								},
+							if let TerminationReason::Abnormal(info) = &reason {
+								error!("Shutting down, {}", info);
 							}
+							run_context.complete();
+							break;
 						},
 					},
 					Err(_) => {
@@ -335,7 +331,7 @@ impl ParachainTracer {
 							for relay_fork in &new_head.relay_parent_hashes {
 								if let Err(e) = tracker.inject_block(*relay_fork, new_head.clone(), &storage).await {
 									error!("error occurred when processing block {}: {:?}", relay_fork, e);
-									run_context.request_restart();
+									run_context.complete();
 									break;
 								}
 								if let Some(progress) = tracker.progress(&mut stats, &metrics, &storage).await &&
@@ -349,15 +345,11 @@ impl ParachainTracer {
 							tracker.inject_new_session(idx);
 						},
 						CollectorUpdateEvent::Termination(reason) => {
-							info!("collector is terminating for parachain {}", para_id);
-							match reason {
-								TerminationReason::Normal => break,
-								TerminationReason::Abnormal(info) => {
-									error!("Shutting down, {}", info);
-									run_context.request_restart();
-									break;
-								},
+							if let TerminationReason::Abnormal(info) = &reason {
+								error!("Shutting down parachain {}, {}", para_id, info);
 							}
+							run_context.complete();
+							break;
 						},
 					},
 					Err(_) => {
@@ -423,16 +415,13 @@ impl ParachainTracer {
 									to_tracker.send(CollectorUpdateEvent::NewSession(idx)).await.unwrap();
 								},
 							CollectorUpdateEvent::Termination(reason) => {
+								if let TerminationReason::Abnormal(info) = &reason {
+									error!("Shutting down, {}", info);
+								}
 								info!("Received termination event, {} trackers will be terminated, {} futures are pending",
 									trackers.len(), futures.len());
-								match reason {
-									TerminationReason::Normal => break,
-									TerminationReason::Abnormal(info) => {
-										error!("Shutting down, {}", info);
-										run_context.request_restart();
-										break;
-									},
-								}
+								run_context.complete();
+								break;
 							},
 						},
 						None => {

--- a/parachain-tracer/src/main.rs
+++ b/parachain-tracer/src/main.rs
@@ -508,16 +508,9 @@ async fn main() -> color_eyre::Result<()> {
 		let shutdown_listener = init::spawn_shutdown_listener(run_context.clone());
 		let mut executor = match tokio::select! {
 			result = RequestExecutor::build(opts.node.clone(), opts.api_client_mode, &opts.retry, &run_context) => result,
-			maybe_outcome = outcome_rx.recv() => {
-				let Some(outcome) = maybe_outcome else {
-					error!("All RunContext senders dropped without signaling an outcome");
-					shutdown_listener.abort();
-					break;
-				};
+			Some(outcome) = outcome_rx.recv() => {
 				shutdown_listener.abort();
-				if outcome.is_restart_requested() && retry.sleep().await.is_ok() {
-					continue;
-				}
+				if outcome.is_restart_requested() && retry.sleep().await.is_ok() { continue; }
 				break;
 			}
 		} {
@@ -541,24 +534,7 @@ async fn main() -> color_eyre::Result<()> {
 		let consumer_init = sub.create_consumer();
 
 		let mut futures = vec![];
-		let tracer_futures = tokio::select! {
-			result = tracer.run(&run_context, consumer_init, &mut executor) => result?,
-			maybe_outcome = outcome_rx.recv() => {
-				let Some(outcome) = maybe_outcome else {
-					error!("All RunContext senders dropped without signaling an outcome");
-					executor.close().await;
-					shutdown_listener.abort();
-					break;
-				};
-				executor.close().await;
-				shutdown_listener.abort();
-				if outcome.is_restart_requested() && retry.sleep().await.is_ok() {
-					continue;
-				}
-				break;
-			}
-		};
-		futures.extend(tracer_futures);
+		futures.extend(tracer.run(&run_context, consumer_init, &mut executor).await?);
 		futures.extend(sub.run(&run_context).await?);
 		let outcome = init::run_supervised(futures, shutdown_listener, &mut outcome_rx).await?;
 		executor.close().await;

--- a/parachain-tracer/src/main.rs
+++ b/parachain-tracer/src/main.rs
@@ -43,7 +43,7 @@ use polkadot_introspector_essentials::{
 	historical_subscription::HistoricalSubscription,
 	init::{self, RunContext},
 	types::BlockNumber,
-	utils::{Retry, RetryOptions},
+	utils::RetryOptions,
 };
 use polkadot_introspector_priority_channel::{Receiver, Sender, channel_with_capacities};
 use prometheus::{Metrics, ParachainTracerPrometheusOptions};
@@ -494,55 +494,31 @@ async fn main() -> color_eyre::Result<()> {
 	let opts = ParachainTracerOptions::parse();
 	init::init_cli(&opts.verbose)?;
 
-	let mut retry = Retry::new(&opts.retry);
-
 	let metrics = if let Some(ParachainTracerMode::Prometheus(ref prometheus_opts)) = opts.mode {
 		prometheus::run_prometheus_endpoint(prometheus_opts).await?
 	} else {
 		Default::default()
 	};
 
-	loop {
-		let tracer = ParachainTracer::new(opts.clone(), metrics.clone())?;
-		let (run_context, mut outcome_rx) = init::init_run_context();
-		let shutdown_listener = init::spawn_shutdown_listener(run_context.clone());
-		let mut executor = match tokio::select! {
-			result = RequestExecutor::build(opts.node.clone(), opts.api_client_mode, &opts.retry, &run_context) => result,
-			Some(outcome) = outcome_rx.recv() => {
-				shutdown_listener.abort();
-				if outcome.is_restart_requested() && retry.sleep().await.is_ok() { continue; }
-				break;
-			}
-		} {
-			Ok(executor) => executor,
-			Err(e) => {
-				shutdown_listener.abort();
-				error!("Failed to build RequestExecutor: {:?}", e);
-				if retry.sleep().await.is_err() {
-					break;
-				}
-				continue;
-			},
-		};
+	let tracer = ParachainTracer::new(opts.clone(), metrics)?;
+	let (run_context, mut outcome_rx) = init::init_run_context();
+	let shutdown_listener = init::spawn_shutdown_listener(run_context.clone());
+	let mut executor =
+		RequestExecutor::build(opts.node.clone(), opts.api_client_mode, &opts.retry, &run_context).await?;
 
-		let mut sub: Box<dyn EventStream<Event = ChainSubscriptionEvent>> = if opts.is_historical {
-			let (from, to) = historical_bounds(&opts)?;
-			Box::new(HistoricalSubscription::new(vec![opts.node.clone()], from, to, executor.clone()))
-		} else {
-			Box::new(ChainHeadSubscription::new(vec![opts.node.clone()], executor.clone()))
-		};
-		let consumer_init = sub.create_consumer();
+	let mut sub: Box<dyn EventStream<Event = ChainSubscriptionEvent>> = if opts.is_historical {
+		let (from, to) = historical_bounds(&opts)?;
+		Box::new(HistoricalSubscription::new(vec![opts.node.clone()], from, to, executor.clone()))
+	} else {
+		Box::new(ChainHeadSubscription::new(vec![opts.node.clone()], executor.clone()))
+	};
+	let consumer_init = sub.create_consumer();
 
-		let mut futures = vec![];
-		futures.extend(tracer.run(&run_context, consumer_init, &mut executor).await?);
-		futures.extend(sub.run(&run_context).await?);
-		let outcome = init::run_supervised(futures, shutdown_listener, &mut outcome_rx).await?;
-		executor.close().await;
-
-		if !outcome.is_restart_requested() || retry.sleep().await.is_err() {
-			break;
-		}
-	}
+	let mut futures = vec![];
+	futures.extend(tracer.run(&run_context, consumer_init, &mut executor).await?);
+	futures.extend(sub.run(&run_context).await?);
+	init::run_supervised(futures, shutdown_listener, &mut outcome_rx).await?;
+	executor.close().await;
 
 	Ok(())
 }

--- a/parachain-tracer/src/main.rs
+++ b/parachain-tracer/src/main.rs
@@ -41,7 +41,7 @@ use polkadot_introspector_essentials::{
 	collector::{self, Collector, CollectorOptions, CollectorStorageApi, CollectorUpdateEvent, TerminationReason},
 	consumer::{EventConsumerInit, EventStream},
 	historical_subscription::HistoricalSubscription,
-	init::{self, Shutdown},
+	init::{self, RunContext},
 	types::BlockNumber,
 	utils::{Retry, RetryOptions},
 };
@@ -49,7 +49,6 @@ use polkadot_introspector_priority_channel::{Receiver, Sender, channel_with_capa
 use prometheus::{Metrics, ParachainTracerPrometheusOptions};
 use stats::ParachainStats;
 use std::{collections::HashMap, default::Default, ops::DerefMut, time::Duration};
-use tokio::sync::broadcast::Sender as BroadcastSender;
 use tracker::SubxtTracker;
 use tracker_storage::TrackerStorage;
 
@@ -139,14 +138,14 @@ impl ParachainTracer {
 	/// Spawn the UI and subxt tasks and return their futures.
 	pub(crate) async fn run(
 		self,
-		shutdown_tx: &BroadcastSender<Shutdown>,
+		run_context: &RunContext,
 		consumer_config: EventConsumerInit<ChainSubscriptionEvent>,
 		executor: &mut RequestExecutor,
 	) -> color_eyre::Result<Vec<tokio::task::JoinHandle<()>>> {
 		let mut output_futures = vec![];
 
 		let mut collector = Collector::new(self.opts.node.as_str(), self.opts.collector_opts.clone(), executor.clone());
-		collector.spawn(shutdown_tx).await?;
+		collector.spawn(run_context).await?;
 
 		println!(
 			"{}\n\twill trace {}\n\ton {}\n\tusing {} Client\n",
@@ -172,7 +171,7 @@ impl ParachainTracer {
 
 		output_futures.push(ParachainTracer::watch_node_for_relay_chain(
 			self.clone(),
-			shutdown_tx.clone(),
+			run_context.clone(),
 			// HACK: We use a fake para id to receive only relay chain events
 			collector.subscribe_parachain_updates(RELAY_CHAIN_ID).await?,
 			collector.api(),
@@ -182,7 +181,7 @@ impl ParachainTracer {
 			let from_collector = collector.subscribe_broadcast_updates().await?;
 			output_futures.push(tokio::spawn(ParachainTracer::watch_node_broadcast(
 				self.clone(),
-				shutdown_tx.clone(),
+				run_context.clone(),
 				from_collector,
 				collector.api(),
 			)));
@@ -191,7 +190,7 @@ impl ParachainTracer {
 				let from_collector = collector.subscribe_parachain_updates(*para_id).await?;
 				output_futures.push(ParachainTracer::watch_node_for_parachain(
 					self.clone(),
-					shutdown_tx.clone(),
+					run_context.clone(),
 					from_collector,
 					*para_id,
 					collector.api(),
@@ -211,7 +210,7 @@ impl ParachainTracer {
 
 	fn watch_node_for_relay_chain(
 		self,
-		shutdown_tx: BroadcastSender<Shutdown>,
+		run_context: RunContext,
 		from_collector: Receiver<CollectorUpdateEvent>,
 		api_service: CollectorStorageApi,
 	) -> tokio::task::JoinHandle<()> {
@@ -293,7 +292,7 @@ impl ParachainTracer {
 								TerminationReason::Normal => break,
 								TerminationReason::Abnormal(info) => {
 									error!("Shutting down, {}", info);
-									let _ = shutdown_tx.send(Shutdown::Restart);
+									run_context.request_restart();
 									break;
 								},
 							}
@@ -312,7 +311,7 @@ impl ParachainTracer {
 	// Follows the stream of events and updates the application state.
 	fn watch_node_for_parachain(
 		self,
-		shutdown_tx: BroadcastSender<Shutdown>,
+		run_context: RunContext,
 		from_collector: Receiver<CollectorUpdateEvent>,
 		para_id: u32,
 		api_service: CollectorStorageApi,
@@ -336,7 +335,7 @@ impl ParachainTracer {
 							for relay_fork in &new_head.relay_parent_hashes {
 								if let Err(e) = tracker.inject_block(*relay_fork, new_head.clone(), &storage).await {
 									error!("error occurred when processing block {}: {:?}", relay_fork, e);
-									let _ = shutdown_tx.send(Shutdown::Restart);
+									run_context.request_restart();
 									break;
 								}
 								if let Some(progress) = tracker.progress(&mut stats, &metrics, &storage).await &&
@@ -355,7 +354,7 @@ impl ParachainTracer {
 								TerminationReason::Normal => break,
 								TerminationReason::Abnormal(info) => {
 									error!("Shutting down, {}", info);
-									let _ = shutdown_tx.send(Shutdown::Restart);
+									run_context.request_restart();
 									break;
 								},
 							}
@@ -378,7 +377,7 @@ impl ParachainTracer {
 
 	async fn watch_node_broadcast(
 		self,
-		shutdown_tx: BroadcastSender<Shutdown>,
+		run_context: RunContext,
 		from_collector: Receiver<CollectorUpdateEvent>,
 		api_service: CollectorStorageApi,
 	) {
@@ -402,7 +401,7 @@ impl ParachainTracer {
 
 								let to_tracker = trackers.entry(para_id).or_insert_with(|| {
 									let (tx, rx) = channel_with_capacities(collector::COLLECTOR_NORMAL_CHANNEL_CAPACITY, 1);
-									futures.push(ParachainTracer::watch_node_for_parachain(self.clone(), shutdown_tx.clone(), rx, para_id, api_service.clone()));
+									futures.push(ParachainTracer::watch_node_for_parachain(self.clone(), run_context.clone(), rx, para_id, api_service.clone()));
 									info!("Added tracker for parachain {}", para_id);
 
 									tx
@@ -430,7 +429,7 @@ impl ParachainTracer {
 									TerminationReason::Normal => break,
 									TerminationReason::Abnormal(info) => {
 										error!("Shutting down, {}", info);
-										let _ = shutdown_tx.send(Shutdown::Restart);
+										run_context.request_restart();
 										break;
 									},
 								}
@@ -505,19 +504,33 @@ async fn main() -> color_eyre::Result<()> {
 
 	loop {
 		let tracer = ParachainTracer::new(opts.clone(), metrics.clone())?;
-		let shutdown_tx = init::init_shutdown();
-		let mut shutdown_rx = shutdown_tx.subscribe();
-		let mut executor =
-			match RequestExecutor::build(opts.node.clone(), opts.api_client_mode, &opts.retry, &shutdown_tx).await {
-				Ok(executor) => executor,
-				Err(e) => {
-					error!("Failed to build RequestExecutor: {:?}", e);
-					if retry.sleep().await.is_err() {
-						break;
-					}
+		let (run_context, mut outcome_rx) = init::init_run_context();
+		let shutdown_listener = init::spawn_shutdown_listener(run_context.clone());
+		let mut executor = match tokio::select! {
+			result = RequestExecutor::build(opts.node.clone(), opts.api_client_mode, &opts.retry, &run_context) => result,
+			maybe_outcome = outcome_rx.recv() => {
+				let Some(outcome) = maybe_outcome else {
+					error!("All RunContext senders dropped without signaling an outcome");
+					shutdown_listener.abort();
+					break;
+				};
+				shutdown_listener.abort();
+				if outcome.is_restart_requested() && retry.sleep().await.is_ok() {
 					continue;
-				},
-			};
+				}
+				break;
+			}
+		} {
+			Ok(executor) => executor,
+			Err(e) => {
+				shutdown_listener.abort();
+				error!("Failed to build RequestExecutor: {:?}", e);
+				if retry.sleep().await.is_err() {
+					break;
+				}
+				continue;
+			},
+		};
 
 		let mut sub: Box<dyn EventStream<Event = ChainSubscriptionEvent>> = if opts.is_historical {
 			let (from, to) = historical_bounds(&opts)?;
@@ -528,17 +541,29 @@ async fn main() -> color_eyre::Result<()> {
 		let consumer_init = sub.create_consumer();
 
 		let mut futures = vec![];
-		futures.extend(tracer.run(&shutdown_tx, consumer_init, &mut executor).await?);
-		futures.extend(sub.run(&shutdown_tx).await?);
-		init::run(futures, &shutdown_tx).await?;
+		let tracer_futures = tokio::select! {
+			result = tracer.run(&run_context, consumer_init, &mut executor) => result?,
+			maybe_outcome = outcome_rx.recv() => {
+				let Some(outcome) = maybe_outcome else {
+					error!("All RunContext senders dropped without signaling an outcome");
+					executor.close().await;
+					shutdown_listener.abort();
+					break;
+				};
+				executor.close().await;
+				shutdown_listener.abort();
+				if outcome.is_restart_requested() && retry.sleep().await.is_ok() {
+					continue;
+				}
+				break;
+			}
+		};
+		futures.extend(tracer_futures);
+		futures.extend(sub.run(&run_context).await?);
+		let outcome = init::run_supervised(futures, shutdown_listener, &mut outcome_rx).await?;
 		executor.close().await;
 
-		let should_break = match shutdown_rx.recv().await {
-			Ok(Shutdown::Restart) => retry.sleep().await.is_err(),
-			_ => true,
-		};
-
-		if should_break {
+		if !outcome.is_restart_requested() || retry.sleep().await.is_err() {
 			break;
 		}
 	}

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -132,8 +132,8 @@ pub fn create_inherent_data(para_id: u32) -> InherentData<Header<u32>> {
 }
 
 pub async fn create_executor() -> executor::RequestExecutor {
-	let shutdown_tx = init::init_shutdown();
-	executor::RequestExecutor::build(rpc_node_url(), ApiClientMode::RPC, &RetryOptions::default(), &shutdown_tx)
+	let (run_context, _outcome_rx) = init::init_run_context();
+	executor::RequestExecutor::build(rpc_node_url(), ApiClientMode::RPC, &RetryOptions::default(), &run_context)
 		.await
 		.unwrap()
 }

--- a/whois/src/main.rs
+++ b/whois/src/main.rs
@@ -524,8 +524,8 @@ async fn main() -> color_eyre::Result<()> {
 	init::init_cli(&opts.verbose)?;
 
 	let whois = Whois::new(opts.clone())?;
-	let shutdown_tx = init::init_shutdown();
-	let executor = RequestExecutor::build(opts.ws.clone(), ApiClientMode::RPC, &opts.retry, &shutdown_tx).await?;
+	let (run_context, _outcome_rx) = init::init_run_context();
+	let executor = RequestExecutor::build(opts.ws.clone(), ApiClientMode::RPC, &opts.retry, &run_context).await?;
 
 	let mut futures = vec![];
 	futures.extend(whois.run(executor).await?);

--- a/whois/src/main.rs
+++ b/whois/src/main.rs
@@ -530,7 +530,10 @@ async fn main() -> color_eyre::Result<()> {
 	let mut futures = vec![];
 	futures.extend(whois.run(executor).await?);
 
-	let _outcome = init::run_supervised(futures, shutdown_listener, &mut outcome_rx).await?;
+	let outcome = init::run_supervised(futures, shutdown_listener, &mut outcome_rx).await?;
+	if outcome.is_restart_requested() {
+		return Err(color_eyre::eyre::eyre!("Unexpected restart requested during whois execution"));
+	}
 
 	Ok(())
 }

--- a/whois/src/main.rs
+++ b/whois/src/main.rs
@@ -15,7 +15,6 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 
 use clap::{Args, Parser, Subcommand};
-use futures::future;
 use itertools::Itertools;
 use libp2p::{Multiaddr, PeerId};
 use polkadot_introspector_essentials::{
@@ -524,13 +523,14 @@ async fn main() -> color_eyre::Result<()> {
 	init::init_cli(&opts.verbose)?;
 
 	let whois = Whois::new(opts.clone())?;
-	let (run_context, _outcome_rx) = init::init_run_context();
+	let (run_context, mut outcome_rx) = init::init_run_context();
+	let shutdown_listener = init::spawn_shutdown_listener(run_context.clone());
 	let executor = RequestExecutor::build(opts.ws.clone(), ApiClientMode::RPC, &opts.retry, &run_context).await?;
 
 	let mut futures = vec![];
 	futures.extend(whois.run(executor).await?);
 
-	future::try_join_all(futures).await?;
+	let _outcome = init::run_supervised(futures, shutdown_listener, &mut outcome_rx).await?;
 
 	Ok(())
 }

--- a/whois/src/main.rs
+++ b/whois/src/main.rs
@@ -530,10 +530,7 @@ async fn main() -> color_eyre::Result<()> {
 	let mut futures = vec![];
 	futures.extend(whois.run(executor).await?);
 
-	let outcome = init::run_supervised(futures, shutdown_listener, &mut outcome_rx).await?;
-	if outcome.is_restart_requested() {
-		return Err(color_eyre::eyre::eyre!("Unexpected restart requested during whois execution"));
-	}
+	init::run_supervised(futures, shutdown_listener, &mut outcome_rx).await?;
 
 	Ok(())
 }


### PR DESCRIPTION
**Summary**

- Replaces BroadcastSender<Shutdown> with a RunContext struct that separates cancellation signaling
(watch) from outcome delivery (mpsc)
- Introduces RunOutcome enum (Completed, RestartRequested, Cancelled) for explicit lifecycle management
- Adds run_supervised that collects abort handles and can terminate stuck workers immediately
- Removes redundant inner retry loop from build_client — connection retries are now handled solely by
the outer main loop
- Switches retry backoff from linear to exponential and makes retry sleep interruptible by ctrl+c

**Motivation**

The broadcast-based shutdown had several problems in practice:

- Missed signals: broadcast receivers that lag behind lose messages; a task checking late could miss
shutdown entirely
- No completion signal: historical subscription had no way to say "I'm done" — it looped on heartbeats
forever after finishing its block range
- Uncancellable init: RequestExecutor::build blocked with no cancellation path; a hanging RPC endpoint
made ctrl+c ineffective
- Race on outcome: multiple tasks sending Shutdown::Restart concurrently, supervisor receiving just one
arbitrarily
- Conflated concerns: "stop what you're doing" and "here's why" both carried on one broadcast channel
- Double retry: build_client had its own 10-attempt retry loop, then the outer main loop retried on top
of that with linear backoff — resulting in ~120 attempts before giving up
- Uninterruptible backoff: ctrl+c was ignored during retry sleep because the shutdown listener was
already aborted