### PR TITLE
Fix parachain-tracer historical mode exit and Ctrl+C handling

### DIFF
--- a/essentials/src/collector/mod.rs
+++ b/essentials/src/collector/mod.rs
@@ -298,67 +298,52 @@ impl Collector {
 	pub async fn run_with_consumer_channel(
 		mut self,
 		consumer_channel: Receiver<ChainSubscriptionEvent>,
+		shutdown_tx: BroadcastSender<()>,
 	) -> tokio::task::JoinHandle<()> {
 		tokio::spawn(async move {
+			let mut shutdown_rx = shutdown_tx.subscribe();
 			let mut consumer_channel = Box::pin(consumer_channel);
 			loop {
-				match consumer_channel.next().await {
-					None => {
-						error!("no more events from the consumer channel");
-						self.broadcast_event_priority(CollectorUpdateEvent::Termination(TerminationReason::Normal))
-							.await
-							.unwrap();
-						return
-					},
-					Some(ChainSubscriptionEvent::Termination) => {
-						info!("subscribtion terminated");
-						self.broadcast_event_priority(CollectorUpdateEvent::Termination(TerminationReason::Normal))
-							.await
-							.unwrap();
-						return
-					},
-					Some(event) => match self.collect_chain_events(&event).await {
-						Ok(subxt_events) =>
-							for event in subxt_events.iter() {
-								if let Err(error) = self.process_chain_event(event).await {
-									error!("collector service could not process event: {:?}", error);
-									match error {
-										CollectorError::ExecutorFatal(e) => {
-											self.broadcast_event_priority(CollectorUpdateEvent::Termination(
-												TerminationReason::Abnormal(format!(
-													"Collector's executor error: {}",
-													e
-												)),
-											))
-											.await
-											.unwrap();
-											return
-										},
-										CollectorError::SendFatal(e) => {
-											self.broadcast_event_priority(CollectorUpdateEvent::Termination(
-												TerminationReason::Abnormal(format!(
-													"Collector's channel error: {}",
-													e
-												)),
-											))
-											.await
-											.unwrap();
-											return
-										},
-										_ => continue,
-									}
-								}
+				tokio::select! {
+					message = consumer_channel.next() => {
+						match message {
+							None | Some(ChainSubscriptionEvent::Termination) => {
+								info!("Subscription terminated");
+								self.terminate(TerminationReason::Normal).await;
+								let _ = shutdown_tx.send(());
+								return
 							},
-						Err(e) => {
-							error!("collector service could not process events: {:?}", e);
-							self.broadcast_event_priority(CollectorUpdateEvent::Termination(
-								TerminationReason::Abnormal(format!("Collector's service error: {}", e)),
-							))
-							.await
-							.unwrap();
-							return
-						},
-					},
+							Some(event) => match self.collect_chain_events(&event).await {
+								Ok(subxt_events) =>
+									for event in subxt_events.iter() {
+										if let Err(error) = self.process_chain_event(event).await {
+											error!("collector service could not process event: {:?}", error);
+											match error {
+												CollectorError::ExecutorFatal(e) => {
+													self.terminate(TerminationReason::Abnormal(format!("Collector's executor error: {}", e))).await;
+													return
+												},
+												CollectorError::SendFatal(e) => {
+													self.terminate(TerminationReason::Abnormal(format!("Collector's channel error: {}", e))).await;
+													return
+												},
+												_ => continue,
+											}
+										}
+									},
+								Err(e) => {
+									error!("collector service could not process events: {:?}", e);
+									self.terminate(TerminationReason::Abnormal(format!("Collector's service error: {}", e))).await;
+									return
+								},
+							},
+						}
+					}
+					_ = shutdown_rx.recv() => {
+						info!("Received shutdown signal in collector");
+						self.terminate(TerminationReason::Normal).await;
+						return;
+					}
 				}
 			}
 		})
@@ -593,18 +578,20 @@ impl Collector {
 	}
 
 	/// Send a priority event to all open channels
-	async fn broadcast_event_priority(&mut self, event: CollectorUpdateEvent) -> color_eyre::Result<()> {
+	async fn broadcast_event_priority(&mut self, event: CollectorUpdateEvent) {
 		for (_, channels) in self.subscribe_channels.iter_mut() {
 			for channel in channels {
-				channel.send_priority(event.clone()).await?;
+				let _ = channel.send_priority(event.clone()).await;
 			}
 		}
 
 		for broadcast_channel in self.broadcast_channels.iter_mut() {
-			broadcast_channel.send_priority(event.clone()).await?;
+			let _ = broadcast_channel.send_priority(event.clone()).await;
 		}
+	}
 
-		Ok(())
+	async fn terminate(&mut self, reason: TerminationReason) {
+		self.broadcast_event_priority(CollectorUpdateEvent::Termination(reason)).await;
 	}
 
 	async fn process_new_best_head(

--- a/essentials/src/historical_subscription.rs
+++ b/essentials/src/historical_subscription.rs
@@ -25,10 +25,7 @@ use crate::{
 use async_trait::async_trait;
 use log::{debug, error, info};
 use polkadot_introspector_priority_channel::{Sender, channel};
-use tokio::{
-	sync::broadcast::{Sender as BroadcastSender, error::TryRecvError},
-	time::{Duration, interval_at},
-};
+use tokio::sync::broadcast::{Sender as BroadcastSender, error::TryRecvError};
 
 pub struct HistoricalSubscription {
 	urls: Vec<String>,
@@ -96,8 +93,6 @@ impl HistoricalSubscription {
 		mut executor: RequestExecutor,
 	) {
 		let mut shutdown_rx = shutdown_tx.subscribe();
-		const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(1000);
-		let mut heartbeat_periodic = interval_at(tokio::time::Instant::now() + HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL);
 
 		let last_block_number = match executor.get_block_number(&url, None).await {
 			Ok(v) => v,
@@ -167,24 +162,8 @@ impl HistoricalSubscription {
 			}
 		}
 
-		loop {
-			// We wait here for termination.
-			tokio::select! {
-				_ = shutdown_rx.recv() => {
-					info!("Received interrupt signal shutting down subscription");
-					return;
-				}
-				_ = heartbeat_periodic.tick() => {
-					debug!("sent heartbeat to subscribers");
-					let res = update_channel.send(ChainSubscriptionEvent::Heartbeat).await;
-					if let Err(e) = res {
-						info!("Event consumer has terminated: {:?}, shutting down", e);
-						return;
-					}
-					heartbeat_periodic = interval_at(tokio::time::Instant::now() + HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL);
-				}
-			}
-		}
+		info!("Historical subscription completed");
+		let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
 	}
 
 	// Sets up per websocket tasks to handle updates and reconnects on errors.

--- a/parachain-tracer/src/main.rs
+++ b/parachain-tracer/src/main.rs
@@ -201,7 +201,7 @@ impl ParachainTracer {
 
 		let consumer_channels: Vec<Receiver<ChainSubscriptionEvent>> = consumer_config.into();
 		let collector_fut = collector
-			.run_with_consumer_channel(consumer_channels.into_iter().next().unwrap())
+			.run_with_consumer_channel(consumer_channels.into_iter().next().unwrap(), shutdown_tx.clone())
 			.await;
 
 		output_futures.push(collector_fut);
@@ -223,86 +223,95 @@ impl ParachainTracer {
 		let mut last_ts = None;
 
 		tokio::spawn(async move {
+			let mut shutdown_rx = shutdown_tx.subscribe();
 			loop {
-				match from_collector.recv().await {
-					Ok(update_event) => match update_event {
-						CollectorUpdateEvent::NewHead(new_head) => {
-							// Happens on startup
-							if new_head.relay_parent_number == 0 {
-								continue
-							}
-
-							let curr_ts = storage
-								.block_timestamp(
-									*new_head
-										.relay_parent_hashes
-										.first()
-										.expect("at least one relay parent hash must be present"),
-								)
-								.await;
-							let block_time = last_ts
-								.and_then(|last| curr_ts.map(|curr| curr.saturating_sub(last)))
-								.map(Duration::from_millis);
-							last_ts = curr_ts;
-							let backed = new_head.candidates_backed.len();
-							let included = new_head.candidates_included.len();
-							let timed_out = new_head.candidates_timed_out.len();
-							metrics.on_new_relay_block(
-								backed,
-								included,
-								timed_out,
-								block_time,
-								new_head.relay_parent_number,
-								new_head
-									.authors_missing_their_slots
-									.iter()
-									.map(|account| account.to_string())
-									.collect(),
-							);
-							if is_cli {
-								println!(
-									"Block {}: backed {}, included {}, timed-out {} {:}",
-									new_head.relay_parent_number,
-									backed,
-									included,
-									timed_out,
-									if new_head.authors_missing_their_slots.is_empty() {
-										"".to_string()
-									} else {
-										format!(
-											", authors missing their slot: {}",
-											new_head
-												.authors_missing_their_slots
-												.iter()
-												.map(|account| account.to_string())
-												.join(", ")
-										)
+				tokio::select! {
+					result = from_collector.recv() => {
+						match result {
+							Ok(update_event) => match update_event {
+								CollectorUpdateEvent::NewHead(new_head) => {
+									// Happens on startup
+									if new_head.relay_parent_number == 0 {
+										continue
 									}
-								);
-							}
-						},
-						CollectorUpdateEvent::NewSession(session_id) => {
-							metrics.on_new_session(session_id);
-							if is_cli {
-								println!("Session {}", session_id);
-							}
-						},
-						CollectorUpdateEvent::Termination(reason) => {
-							info!("collector is terminating");
-							match reason {
-								TerminationReason::Normal => break,
-								TerminationReason::Abnormal(info) => {
-									error!("Shutting down, {}", info);
-									let _ = shutdown_tx.send(());
-									break;
+
+									let curr_ts = storage
+										.block_timestamp(
+											*new_head
+												.relay_parent_hashes
+												.first()
+												.expect("at least one relay parent hash must be present"),
+										)
+										.await;
+									let block_time = last_ts
+										.and_then(|last| curr_ts.map(|curr| curr.saturating_sub(last)))
+										.map(Duration::from_millis);
+									last_ts = curr_ts;
+									let backed = new_head.candidates_backed.len();
+									let included = new_head.candidates_included.len();
+									let timed_out = new_head.candidates_timed_out.len();
+									metrics.on_new_relay_block(
+										backed,
+										included,
+										timed_out,
+										block_time,
+										new_head.relay_parent_number,
+										new_head
+											.authors_missing_their_slots
+											.iter()
+											.map(|account| account.to_string())
+											.collect(),
+									);
+									if is_cli {
+										println!(
+											"Block {}: backed {}, included {}, timed-out {} {:}",
+											new_head.relay_parent_number,
+											backed,
+											included,
+											timed_out,
+											if new_head.authors_missing_their_slots.is_empty() {
+												"".to_string()
+											} else {
+												format!(
+													", authors missing their slot: {}",
+													new_head
+														.authors_missing_their_slots
+														.iter()
+														.map(|account| account.to_string())
+														.join(", ")
+												)
+											}
+										);
+									}
 								},
-							}
-						},
-					},
-					Err(_) => {
-						info!("Input channel has been closed");
-						break
-					},
+								CollectorUpdateEvent::NewSession(session_id) => {
+									metrics.on_new_session(session_id);
+									if is_cli {
+										println!("Session {}", session_id);
+									}
+								},
+								CollectorUpdateEvent::Termination(reason) => {
+									info!("collector is terminating");
+									match reason {
+										TerminationReason::Normal => break,
+										TerminationReason::Abnormal(info) => {
+											error!("Shutting down, {}", info);
+											let _ = shutdown_tx.send(());
+											break;
+										},
+									}
+								},
+							},
+							Err(_) => {
+								info!("Input channel has been closed");
+								break
+							},
+						}
+					}
+					_ = shutdown_rx.recv() => {
+						info!("Received shutdown signal in relay chain watcher");
+						break;
+					}
 				}
 			}
 		})
@@ -329,42 +338,51 @@ impl ParachainTracer {
 		info!("Starting tracker for parachain {}", para_id);
 
 		tokio::spawn(async move {
+			let mut shutdown_rx = shutdown_tx.subscribe();
 			loop {
-				match from_collector.recv().await {
-					Ok(update_event) => match update_event {
-						CollectorUpdateEvent::NewHead(new_head) =>
-							for relay_fork in &new_head.relay_parent_hashes {
-								if let Err(e) = tracker.inject_block(*relay_fork, new_head.clone(), &storage).await {
-									error!("error occurred when processing block {}: {:?}", relay_fork, e);
-									let _ = shutdown_tx.send(());
-									break;
-								}
-								if let Some(progress) = tracker.progress(&mut stats, &metrics, &storage).await &&
-									is_cli
-								{
-									println!("{}", progress)
-								}
-								tracker.maybe_reset_state();
-							},
-						CollectorUpdateEvent::NewSession(idx) => {
-							tracker.inject_new_session(idx);
-						},
-						CollectorUpdateEvent::Termination(reason) => {
-							info!("collector is terminating for parachain {}", para_id);
-							match reason {
-								TerminationReason::Normal => break,
-								TerminationReason::Abnormal(info) => {
-									error!("Shutting down, {}", info);
-									let _ = shutdown_tx.send(());
-									break;
+				tokio::select! {
+					result = from_collector.recv() => {
+						match result {
+							Ok(update_event) => match update_event {
+								CollectorUpdateEvent::NewHead(new_head) =>
+									for relay_fork in &new_head.relay_parent_hashes {
+										if let Err(e) = tracker.inject_block(*relay_fork, new_head.clone(), &storage).await {
+											error!("error occurred when processing block {}: {:?}", relay_fork, e);
+											let _ = shutdown_tx.send(());
+											break;
+										}
+										if let Some(progress) = tracker.progress(&mut stats, &metrics, &storage).await &&
+											is_cli
+										{
+											println!("{}", progress)
+										}
+										tracker.maybe_reset_state();
+									},
+								CollectorUpdateEvent::NewSession(idx) => {
+									tracker.inject_new_session(idx);
 								},
-							}
-						},
-					},
-					Err(_) => {
-						info!("Input channel has been closed for parachain {}", para_id);
-						break
-					},
+								CollectorUpdateEvent::Termination(reason) => {
+									info!("collector is terminating for parachain {}", para_id);
+									match reason {
+										TerminationReason::Normal => break,
+										TerminationReason::Abnormal(info) => {
+											error!("Shutting down, {}", info);
+											let _ = shutdown_tx.send(());
+											break;
+										},
+									}
+								},
+							},
+							Err(_) => {
+								info!("Input channel has been closed for parachain {}", para_id);
+								break
+							},
+						}
+					}
+					_ = shutdown_rx.recv() => {
+						info!("Received shutdown signal in parachain {} watcher", para_id);
+						break;
+					}
 				}
 			}
 
@@ -382,6 +400,7 @@ impl ParachainTracer {
 		from_collector: Receiver<CollectorUpdateEvent>,
 		api_service: CollectorStorageApi,
 	) {
+		let mut shutdown_rx = shutdown_tx.subscribe();
 		let mut trackers = HashMap::new();
 		// Used to track last block seen in parachain to evict stalled parachains
 		// Another approach would be a BtreeMap indexed by a block number, but
@@ -443,6 +462,10 @@ impl ParachainTracer {
 					};
 				},
 				Some(_) = futures.next() => {},
+				_ = shutdown_rx.recv() => {
+					info!("Received shutdown signal in broadcast watcher");
+					break;
+				}
 				else => break,
 			}
 		}


### PR DESCRIPTION
Fixes historical mode hanging after processing all blocks by sending a Termination event instead of entering an infinite heartbeat loop
