### PR TITLE
parachain-tracer: Switch candidate events and inherent data to dynamic decoding

### DIFF
--- a/essentials/src/api/api_client.rs
+++ b/essentials/src/api/api_client.rs
@@ -16,6 +16,7 @@
 //
 
 use crate::{
+	api::dynamic::decode_para_inherent_fields,
 	metadata::{
 		polkadot::{
 			self,
@@ -31,8 +32,8 @@ use crate::{
 		polkadot_staging_primitives::CoreState,
 	},
 	types::{
-		AccountId32, BlockNumber, ClaimQueue, H256, Header, InherentData, PolkadotHasher, QueuedKeys, SessionKeys,
-		SubxtHrmpChannel, Timestamp,
+		AccountId32, BlockNumber, ClaimQueue, H256, Header, ParaInherentFields, PolkadotHasher, QueuedKeys,
+		SessionKeys, SubxtHrmpChannel, Timestamp,
 	},
 };
 use clap::ValueEnum;
@@ -366,7 +367,7 @@ impl<T: OnlineClientT<PolkadotConfig>> ApiClient<T> {
 		}
 	}
 
-	pub async fn extract_parainherent(&self, maybe_hash: Option<H256>) -> Result<InherentData, subxt::Error> {
+	pub async fn extract_parainherent(&self, maybe_hash: Option<H256>) -> Result<ParaInherentFields, subxt::Error> {
 		let block = self.block_at(maybe_hash).await?;
 		let ex = block
 			.extrinsics()
@@ -375,12 +376,11 @@ impl<T: OnlineClientT<PolkadotConfig>> ApiClient<T> {
 			.take(2)
 			.last()
 			.ok_or_else(|| "`ParaInherent` data is always at index #1".to_string())?;
-		let enter = ex
-			.as_extrinsic::<polkadot::para_inherent::calls::types::Enter>()
-			.map_err(|_| "Failed to decode `ParaInherent`".to_string())?
-			.ok_or_else(|| "`ParaInherent` must exist".to_string())?;
-
-		Ok(enter.data)
+		let field_values = ex
+			.field_values()
+			.map_err(|e| format!("Failed to get ParaInherent field values: {e}"))?;
+		decode_para_inherent_fields(&field_values)
+			.map_err(|e| subxt::Error::Other(format!("Failed to decode ParaInherent: {e}")))
 	}
 
 	// We need it only for the historical mode to convert block numbers into their hashes

--- a/essentials/src/api/api_client.rs
+++ b/essentials/src/api/api_client.rs
@@ -16,7 +16,7 @@
 //
 
 use crate::{
-	api::dynamic::decode_para_inherent_fields,
+	api::dynamic::{decode_availability_cores, decode_inherent_data},
 	metadata::polkadot::{
 		self,
 		runtime_types::{
@@ -29,7 +29,7 @@ use crate::{
 		},
 	},
 	types::{
-		AccountId32, BlockNumber, ClaimQueue, H256, Header, ParaInherentFields, PolkadotHasher, QueuedKeys,
+		AccountId32, BlockNumber, ClaimQueue, CoreOccupied, H256, Header, InherentData, PolkadotHasher, QueuedKeys,
 		SessionKeys, SubxtHrmpChannel, Timestamp,
 	},
 };
@@ -249,6 +249,13 @@ impl<T: OnlineClientT<PolkadotConfig>> ApiClient<T> {
 		self.storage().at(hash).fetch(&addr).await
 	}
 
+	pub async fn get_occupied_cores(&self, hash: H256) -> Result<Vec<CoreOccupied>, subxt::Error> {
+		let addr = subxt::runtime_api::dynamic("ParachainHost", "availability_cores", Vec::<Value<()>>::new());
+		let value = self.runtime_api_at(Some(hash)).await?.call(addr).await?.to_value()?;
+		decode_availability_cores(&value)
+			.map_err(|e| subxt::Error::Other(format!("Failed to decode availability_cores: {e}")))
+	}
+
 	pub async fn get_claim_queue(&self, hash: H256) -> Result<ClaimQueue, subxt::Error> {
 		let addr = polkadot::apis().parachain_host().claim_queue();
 		self.runtime_api_at(Some(hash)).await?.call(addr).await.map(|queue| {
@@ -359,19 +366,7 @@ impl<T: OnlineClientT<PolkadotConfig>> ApiClient<T> {
 		}
 	}
 
-	pub async fn fetch_dynamic_runtime_api(
-		&self,
-		maybe_hash: Option<H256>,
-		trait_name: &str,
-		method_name: &str,
-	) -> Result<Value<u32>, subxt::Error> {
-		let api = self.runtime_api_at(maybe_hash).await?;
-		let payload = subxt::runtime_api::dynamic(trait_name, method_name, Vec::<Value<()>>::new());
-		let result = api.call(payload).await?;
-		result.to_value().map_err(Into::into)
-	}
-
-	pub async fn extract_parainherent(&self, maybe_hash: Option<H256>) -> Result<ParaInherentFields, subxt::Error> {
+	pub async fn extract_parainherent(&self, maybe_hash: Option<H256>) -> Result<InherentData, subxt::Error> {
 		let block = self.block_at(maybe_hash).await?;
 		let ex = block
 			.extrinsics()
@@ -380,11 +375,10 @@ impl<T: OnlineClientT<PolkadotConfig>> ApiClient<T> {
 			.take(2)
 			.last()
 			.ok_or_else(|| "`ParaInherent` data is always at index #1".to_string())?;
-		let field_values = ex
-			.field_values()
-			.map_err(|e| format!("Failed to get ParaInherent field values: {e}"))?;
-		decode_para_inherent_fields(&field_values)
-			.map_err(|e| subxt::Error::Other(format!("Failed to decode ParaInherent: {e}")))
+		ex.field_values()
+			.map_err(|e| format!("Failed to get ParaInherent field values: {e}"))
+			.and_then(|v| decode_inherent_data(&v).map_err(|e| format!("Failed to decode ParaInherent: {e}")))
+			.map_err(subxt::Error::Other)
 	}
 
 	// We need it only for the historical mode to convert block numbers into their hashes

--- a/essentials/src/api/api_client.rs
+++ b/essentials/src/api/api_client.rs
@@ -17,19 +17,16 @@
 
 use crate::{
 	api::dynamic::decode_para_inherent_fields,
-	metadata::{
-		polkadot::{
-			self,
-			runtime_types::{
-				polkadot_parachain_primitives::primitives::{HrmpChannelId, Id},
-				polkadot_runtime_parachains::hrmp::HrmpChannel,
-				sp_consensus_babe::{self, digests::PreDigest},
-				sp_consensus_slots::Slot,
-				sp_core::crypto::KeyTypeId,
-				sp_runtime::generic::digest::DigestItem,
-			},
+	metadata::polkadot::{
+		self,
+		runtime_types::{
+			polkadot_parachain_primitives::primitives::{HrmpChannelId, Id},
+			polkadot_runtime_parachains::hrmp::HrmpChannel,
+			sp_consensus_babe::{self, digests::PreDigest},
+			sp_consensus_slots::Slot,
+			sp_core::crypto::KeyTypeId,
+			sp_runtime::generic::digest::DigestItem,
 		},
-		polkadot_staging_primitives::CoreState,
 	},
 	types::{
 		AccountId32, BlockNumber, ClaimQueue, H256, Header, ParaInherentFields, PolkadotHasher, QueuedKeys,
@@ -252,11 +249,6 @@ impl<T: OnlineClientT<PolkadotConfig>> ApiClient<T> {
 		self.storage().at(hash).fetch(&addr).await
 	}
 
-	pub async fn get_occupied_cores(&self, hash: H256) -> Result<Vec<CoreState<H256, u32>>, subxt::Error> {
-		let addr = polkadot::apis().parachain_host().availability_cores();
-		self.runtime_api_at(Some(hash)).await?.call(addr).await
-	}
-
 	pub async fn get_claim_queue(&self, hash: H256) -> Result<ClaimQueue, subxt::Error> {
 		let addr = polkadot::apis().parachain_host().claim_queue();
 		self.runtime_api_at(Some(hash)).await?.call(addr).await.map(|queue| {
@@ -365,6 +357,18 @@ impl<T: OnlineClientT<PolkadotConfig>> ApiClient<T> {
 			Some(v) => Ok(Some(v.to_value()?)),
 			None => Ok(None),
 		}
+	}
+
+	pub async fn fetch_dynamic_runtime_api(
+		&self,
+		maybe_hash: Option<H256>,
+		trait_name: &str,
+		method_name: &str,
+	) -> Result<Value<u32>, subxt::Error> {
+		let api = self.runtime_api_at(maybe_hash).await?;
+		let payload = subxt::runtime_api::dynamic(trait_name, method_name, Vec::<Value<()>>::new());
+		let result = api.call(payload).await?;
+		result.to_value().map_err(Into::into)
 	}
 
 	pub async fn extract_parainherent(&self, maybe_hash: Option<H256>) -> Result<ParaInherentFields, subxt::Error> {

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -19,11 +19,11 @@ use crate::{
 	metadata::{
 		polkadot::runtime_types::polkadot_core_primitives::CandidateHash,
 		polkadot_primitives::{
-			AvailabilityBitfield, DisputeStatement, DisputeStatementSet, InvalidDisputeStatementKind,
-			ValidDisputeStatementKind, ValidatorIndex, validator_app,
+			AvailabilityBitfield, DisputeStatement, InvalidDisputeStatementKind, ValidDisputeStatementKind,
+			ValidatorIndex,
 		},
 	},
-	types::{CoreOccupied, H256, OnDemandOrder, ParaInherentFields},
+	types::{CoreOccupied, DisputeStatementSet, H256, OnDemandOrder, ParaInherentFields},
 };
 use subxt::{
 	OnlineClient, PolkadotConfig,
@@ -294,8 +294,7 @@ fn decode_dispute_statement_set(value: &Value<u32>) -> Result<DisputeStatementSe
 		}
 		let statement = decode_dispute_statement(&tuple[0])?;
 		let validator_index = ValidatorIndex(decode_dynamic_u32(&tuple[1])?);
-		let signature = decode_validator_signature(&tuple[2])?;
-		statements.push((statement, validator_index, signature));
+		statements.push((statement, validator_index));
 	}
 
 	Ok(DisputeStatementSet { candidate_hash, session, statements })
@@ -384,20 +383,6 @@ fn decode_candidate_hash(value: &Value<u32>) -> Result<CandidateHash, DynamicErr
 			"CandidateHash (unnamed 1-tuple or named composite with field '0')".to_string(),
 			other.clone(),
 		)),
-	}
-}
-
-fn decode_validator_signature(value: &Value<u32>) -> Result<validator_app::Signature, DynamicError> {
-	match &value.value {
-		ValueDef::Composite(Composite::Unnamed(inner)) if inner.len() == 1 => decode_validator_signature(&inner[0]),
-		ValueDef::Composite(Composite::Unnamed(bytes)) if bytes.len() == 64 => {
-			let decoded = decode_byte_slice(bytes)?;
-			let arr: [u8; 64] = decoded.try_into().map_err(|v: Vec<u8>| {
-				DynamicError::DecodeDynamicError(format!("64 bytes (got {})", v.len()), value.value.clone())
-			})?;
-			Ok(validator_app::Signature(arr))
-		},
-		other => Err(DynamicError::DecodeDynamicError("64-byte signature".to_string(), other.clone())),
 	}
 }
 

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -102,7 +102,9 @@ pub(crate) fn decode_candidate_event(raw: &Composite<u32>) -> Result<(u32, H256,
 
 fn decode_dynamic_u32(value: &Value<u32>) -> Result<u32, DynamicError> {
 	match &value.value {
-		ValueDef::Primitive(Primitive::U128(v)) => Ok(*v as u32),
+		ValueDef::Primitive(Primitive::U128(v)) => u32::try_from(*v).map_err(|_| {
+			DynamicError::DecodeDynamicError(format!("u32 value (got {} which overflows u32)", v), value.value.clone())
+		}),
 		ValueDef::Composite(Composite::Unnamed(inner)) if !inner.is_empty() => decode_dynamic_u32(&inner[0]),
 		other => Err(DynamicError::DecodeDynamicError("u32-like value".to_string(), other.clone())),
 	}
@@ -120,7 +122,13 @@ fn decode_h256_from_bytes(bytes: &[Value<u32>]) -> Result<H256, DynamicError> {
 	let mut arr = [0u8; 32];
 	for (i, b) in bytes.iter().enumerate() {
 		match &b.value {
-			ValueDef::Primitive(Primitive::U128(v)) => arr[i] = *v as u8,
+			ValueDef::Primitive(Primitive::U128(v)) =>
+				arr[i] = u8::try_from(*v).map_err(|_| {
+					DynamicError::DecodeDynamicError(
+						format!("u8 at index {} (got {} which overflows u8)", i, v),
+						b.value.clone(),
+					)
+				})?,
 			other => return Err(DynamicError::DecodeDynamicError(format!("u8 at index {}", i), other.clone())),
 		}
 	}
@@ -390,10 +398,18 @@ fn decode_candidate_hash(value: &Value<u32>) -> Result<CandidateHash, DynamicErr
 			let hash_val = fields
 				.iter()
 				.find_map(|(name, val)| if name == "0" { Some(val) } else { None })
-				.unwrap_or(value);
+				.ok_or_else(|| {
+					DynamicError::DecodeDynamicError(
+						"field '0' in named CandidateHash composite".to_string(),
+						value.value.clone(),
+					)
+				})?;
 			Ok(CandidateHash(decode_h256(hash_val)?))
 		},
-		_ => Ok(CandidateHash(decode_h256(value)?)),
+		other => Err(DynamicError::DecodeDynamicError(
+			"CandidateHash (unnamed 1-tuple or named composite with field '0')".to_string(),
+			other.clone(),
+		)),
 	}
 }
 
@@ -404,7 +420,13 @@ fn decode_validator_signature(value: &Value<u32>) -> Result<validator_app::Signa
 			let mut arr = [0u8; 64];
 			for (i, b) in bytes.iter().enumerate() {
 				match &b.value {
-					ValueDef::Primitive(Primitive::U128(v)) => arr[i] = *v as u8,
+					ValueDef::Primitive(Primitive::U128(v)) =>
+						arr[i] = u8::try_from(*v).map_err(|_| {
+							DynamicError::DecodeDynamicError(
+								format!("u8 at signature index {} (got {} which overflows u8)", i, v),
+								b.value.clone(),
+							)
+						})?,
 					other =>
 						return Err(DynamicError::DecodeDynamicError(
 							format!("u8 at signature index {}", i),

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -50,18 +50,15 @@ impl From<subxt::error::Error> for DynamicError {
 }
 
 pub(crate) fn decode_validator_groups(raw_groups: &Value<u32>) -> Result<Vec<Vec<ValidatorIndex>>, DynamicError> {
-	let decoded_groups = decode_unnamed_composite(raw_groups)?;
-	let mut groups = Vec::with_capacity(decoded_groups.len());
-	for raw_group in decoded_groups.iter() {
-		let decoded_group = decode_unnamed_composite(raw_group)?;
-		let mut group = Vec::with_capacity(decoded_group.len());
-		for raw_index in decoded_group.iter() {
-			group.push(ValidatorIndex(decode_composite_u128_value(raw_index)? as u32));
-		}
-		groups.push(group)
-	}
-
-	Ok(groups)
+	decode_unnamed_composite(raw_groups)?
+		.iter()
+		.map(|raw_group| {
+			decode_unnamed_composite(raw_group)?
+				.iter()
+				.map(|raw_index| Ok(ValidatorIndex(decode_composite_u128_value(raw_index)? as u32)))
+				.collect()
+		})
+		.collect()
 }
 
 pub(crate) fn decode_candidate_event(raw: &Composite<u32>) -> Result<(u32, H256, u32), DynamicError> {
@@ -118,41 +115,57 @@ fn decode_h256(value: &Value<u32>) -> Result<H256, DynamicError> {
 	}
 }
 
+fn decode_byte_slice(bytes: &[Value<u32>]) -> Result<Vec<u8>, DynamicError> {
+	bytes
+		.iter()
+		.enumerate()
+		.map(|(i, b)| match &b.value {
+			ValueDef::Primitive(Primitive::U128(v)) => u8::try_from(*v).map_err(|_| {
+				DynamicError::DecodeDynamicError(
+					format!("u8 at index {} (got {} which overflows u8)", i, v),
+					b.value.clone(),
+				)
+			}),
+			other => Err(DynamicError::DecodeDynamicError(format!("u8 at index {}", i), other.clone())),
+		})
+		.collect()
+}
+
 fn decode_h256_from_bytes(bytes: &[Value<u32>]) -> Result<H256, DynamicError> {
-	let mut arr = [0u8; 32];
-	for (i, b) in bytes.iter().enumerate() {
-		match &b.value {
-			ValueDef::Primitive(Primitive::U128(v)) =>
-				arr[i] = u8::try_from(*v).map_err(|_| {
-					DynamicError::DecodeDynamicError(
-						format!("u8 at index {} (got {} which overflows u8)", i, v),
-						b.value.clone(),
-					)
-				})?,
-			other => return Err(DynamicError::DecodeDynamicError(format!("u8 at index {}", i), other.clone())),
-		}
-	}
+	let decoded = decode_byte_slice(bytes)?;
+	let arr: [u8; 32] = decoded.try_into().map_err(|v: Vec<u8>| {
+		DynamicError::DecodeDynamicError(
+			format!("32 bytes (got {})", v.len()),
+			ValueDef::Composite(Composite::Unnamed(bytes.to_vec())),
+		)
+	})?;
 	Ok(H256::from(arr))
+}
+
+fn find_named_field<'a>(
+	fields: &'a [(String, Value<u32>)],
+	name: &str,
+	context: &Composite<u32>,
+) -> Result<&'a Value<u32>, DynamicError> {
+	fields
+		.iter()
+		.find_map(|(field, value)| if field == name { Some(value) } else { None })
+		.ok_or_else(|| {
+			DynamicError::DecodeDynamicError(format!("field '{}'", name), ValueDef::Composite(context.clone()))
+		})
+}
+
+fn variant_inner_value<'a>(variant: &'a Variant<u32>, context: &str) -> Result<&'a Value<u32>, DynamicError> {
+	variant.values.values().next().ok_or_else(|| {
+		DynamicError::DecodeDynamicError(format!("inner value for {}", context), ValueDef::Variant(variant.clone()))
+	})
 }
 
 pub(crate) fn decode_on_demand_order(raw: &Composite<u32>) -> Result<OnDemandOrder, DynamicError> {
 	match raw {
 		Composite::Named(v) => {
-			let raw_para_id = v
-				.iter()
-				.find_map(|(field, value)| if field == "para_id" { Some(value) } else { None })
-				.ok_or(DynamicError::DecodeDynamicError(
-					"named composite with field `para_id`".to_string(),
-					ValueDef::Composite(raw.clone()),
-				))?;
-			let raw_spot_price = v
-				.iter()
-				.find_map(|(field, value)| if field == "spot_price" { Some(value) } else { None })
-				.ok_or(DynamicError::DecodeDynamicError(
-					"named composite with field `spot_price`".to_string(),
-					ValueDef::Composite(raw.clone()),
-				))?;
-
+			let raw_para_id = find_named_field(v, "para_id", raw)?;
+			let raw_spot_price = find_named_field(v, "spot_price", raw)?;
 			Ok(OnDemandOrder {
 				para_id: decode_composite_u128_value(raw_para_id)? as u32,
 				spot_price: decode_u128_value(raw_spot_price)?,
@@ -184,37 +197,26 @@ fn decode_u128_value(value: &Value<u32>) -> Result<u128, DynamicError> {
 }
 
 pub(crate) fn decode_availability_cores(raw: &Value<u32>) -> Result<Vec<CoreOccupied>, DynamicError> {
-	let cores = decode_unnamed_composite(raw)?;
-	let mut result = Vec::with_capacity(cores.len());
-	for core in cores {
-		match &core.value {
+	decode_unnamed_composite(raw)?
+		.iter()
+		.map(|core| match &core.value {
 			ValueDef::Variant(variant) => match variant.name.as_str() {
-				"Free" => result.push(CoreOccupied::Free),
-				"Scheduled" => result.push(CoreOccupied::Scheduled),
-				"Occupied" => result.push(CoreOccupied::Occupied),
-				other =>
-					return Err(DynamicError::DecodeDynamicError(
-						format!("CoreState variant (Free/Scheduled/Occupied), got '{}'", other),
-						core.value.clone(),
-					)),
+				"Free" => Ok(CoreOccupied::Free),
+				"Scheduled" => Ok(CoreOccupied::Scheduled),
+				"Occupied" => Ok(CoreOccupied::Occupied),
+				other => Err(DynamicError::DecodeDynamicError(
+					format!("CoreState variant (Free/Scheduled/Occupied), got '{}'", other),
+					core.value.clone(),
+				)),
 			},
-			other => return Err(DynamicError::DecodeDynamicError("variant for CoreState".to_string(), other.clone())),
-		}
-	}
-	Ok(result)
+			other => Err(DynamicError::DecodeDynamicError("variant for CoreState".to_string(), other.clone())),
+		})
+		.collect()
 }
 
 pub(crate) fn decode_para_inherent_fields(raw: &Composite<u32>) -> Result<ParaInherentFields, DynamicError> {
 	let data = match raw {
-		Composite::Named(fields) => fields
-			.iter()
-			.find_map(|(name, val)| if name == "data" { Some(val) } else { None })
-			.ok_or_else(|| {
-				DynamicError::DecodeDynamicError(
-					"named composite with 'data' field".to_string(),
-					ValueDef::Composite(raw.clone()),
-				)
-			})?,
+		Composite::Named(fields) => find_named_field(fields, "data", raw)?,
 		Composite::Unnamed(fields) if !fields.is_empty() => &fields[0],
 		_ =>
 			return Err(DynamicError::DecodeDynamicError(
@@ -226,25 +228,25 @@ pub(crate) fn decode_para_inherent_fields(raw: &Composite<u32>) -> Result<ParaIn
 	let raw_bitfields = data
 		.at("bitfields")
 		.ok_or_else(|| DynamicError::DecodeDynamicError("bitfields field".to_string(), data.value.clone()))?;
-	let bitfields_vec = decode_unnamed_composite(raw_bitfields)?;
-	let mut bitfields = Vec::with_capacity(bitfields_vec.len());
-	for raw_signed in bitfields_vec {
-		let payload = raw_signed.at("payload").ok_or_else(|| {
-			DynamicError::DecodeDynamicError("payload field in bitfield".to_string(), raw_signed.value.clone())
-		})?;
-		bitfields.push(decode_availability_bitfield(payload)?);
-	}
+	let bitfields: Result<Vec<_>, _> = decode_unnamed_composite(raw_bitfields)?
+		.iter()
+		.map(|raw_signed| {
+			let payload = raw_signed.at("payload").ok_or_else(|| {
+				DynamicError::DecodeDynamicError("payload field in bitfield".to_string(), raw_signed.value.clone())
+			})?;
+			decode_availability_bitfield(payload)
+		})
+		.collect();
 
 	let raw_disputes = data
 		.at("disputes")
 		.ok_or_else(|| DynamicError::DecodeDynamicError("disputes field".to_string(), data.value.clone()))?;
-	let disputes_vec = decode_unnamed_composite(raw_disputes)?;
-	let mut disputes = Vec::with_capacity(disputes_vec.len());
-	for raw_dispute in disputes_vec {
-		disputes.push(decode_dispute_statement_set(raw_dispute)?);
-	}
+	let disputes: Result<Vec<_>, _> = decode_unnamed_composite(raw_disputes)?
+		.iter()
+		.map(decode_dispute_statement_set)
+		.collect();
 
-	Ok(ParaInherentFields { bitfields, disputes })
+	Ok(ParaInherentFields { bitfields: bitfields?, disputes: disputes? })
 }
 
 fn decode_availability_bitfield(value: &Value<u32>) -> Result<AvailabilityBitfield, DynamicError> {
@@ -302,14 +304,8 @@ fn decode_dispute_statement_set(value: &Value<u32>) -> Result<DisputeStatementSe
 fn decode_dispute_statement(value: &Value<u32>) -> Result<DisputeStatement, DynamicError> {
 	match &value.value {
 		ValueDef::Variant(variant) => match variant.name.as_str() {
-			"Valid" => {
-				let kind = decode_valid_dispute_statement_kind(variant)?;
-				Ok(DisputeStatement::Valid(kind))
-			},
-			"Invalid" => {
-				let kind = decode_invalid_dispute_statement_kind(variant)?;
-				Ok(DisputeStatement::Invalid(kind))
-			},
+			"Valid" => Ok(DisputeStatement::Valid(decode_valid_dispute_statement_kind(variant)?)),
+			"Invalid" => Ok(DisputeStatement::Invalid(decode_invalid_dispute_statement_kind(variant)?)),
 			other => Err(DynamicError::DecodeDynamicError(
 				format!("Valid or Invalid dispute statement, got '{}'", other),
 				value.value.clone(),
@@ -320,41 +316,24 @@ fn decode_dispute_statement(value: &Value<u32>) -> Result<DisputeStatement, Dyna
 }
 
 fn decode_valid_dispute_statement_kind(variant: &Variant<u32>) -> Result<ValidDisputeStatementKind, DynamicError> {
-	let inner = variant.values.values().next().ok_or_else(|| {
-		DynamicError::DecodeDynamicError(
-			"inner variant for ValidDisputeStatementKind".to_string(),
-			ValueDef::Variant(variant.clone()),
-		)
-	})?;
+	let inner = variant_inner_value(variant, "ValidDisputeStatementKind")?;
 	match &inner.value {
 		ValueDef::Variant(inner_variant) => match inner_variant.name.as_str() {
 			"Explicit" => Ok(ValidDisputeStatementKind::Explicit),
 			"BackingSeconded" => {
-				let hash_val = inner_variant.values.values().next().ok_or_else(|| {
-					DynamicError::DecodeDynamicError("hash in BackingSeconded".to_string(), inner.value.clone())
-				})?;
+				let hash_val = variant_inner_value(inner_variant, "BackingSeconded")?;
 				Ok(ValidDisputeStatementKind::BackingSeconded(decode_h256(hash_val)?))
 			},
 			"BackingValid" => {
-				let hash_val = inner_variant.values.values().next().ok_or_else(|| {
-					DynamicError::DecodeDynamicError("hash in BackingValid".to_string(), inner.value.clone())
-				})?;
+				let hash_val = variant_inner_value(inner_variant, "BackingValid")?;
 				Ok(ValidDisputeStatementKind::BackingValid(decode_h256(hash_val)?))
 			},
 			"ApprovalChecking" => Ok(ValidDisputeStatementKind::ApprovalChecking),
 			"ApprovalCheckingMultipleCandidates" => {
-				let candidates_val = inner_variant.values.values().next().ok_or_else(|| {
-					DynamicError::DecodeDynamicError(
-						"candidates in ApprovalCheckingMultipleCandidates".to_string(),
-						inner.value.clone(),
-					)
-				})?;
+				let candidates_val = variant_inner_value(inner_variant, "ApprovalCheckingMultipleCandidates")?;
 				let candidates_vec = decode_unnamed_composite(candidates_val)?;
-				let mut candidates = Vec::with_capacity(candidates_vec.len());
-				for c in candidates_vec {
-					candidates.push(decode_candidate_hash(c)?);
-				}
-				Ok(ValidDisputeStatementKind::ApprovalCheckingMultipleCandidates(candidates))
+				let candidates: Result<Vec<_>, _> = candidates_vec.iter().map(decode_candidate_hash).collect();
+				Ok(ValidDisputeStatementKind::ApprovalCheckingMultipleCandidates(candidates?))
 			},
 			other => Err(DynamicError::DecodeDynamicError(
 				format!("known ValidDisputeStatementKind, got '{}'", other),
@@ -369,12 +348,7 @@ fn decode_valid_dispute_statement_kind(variant: &Variant<u32>) -> Result<ValidDi
 }
 
 fn decode_invalid_dispute_statement_kind(variant: &Variant<u32>) -> Result<InvalidDisputeStatementKind, DynamicError> {
-	let inner = variant.values.values().next().ok_or_else(|| {
-		DynamicError::DecodeDynamicError(
-			"inner variant for InvalidDisputeStatementKind".to_string(),
-			ValueDef::Variant(variant.clone()),
-		)
-	})?;
+	let inner = variant_inner_value(variant, "InvalidDisputeStatementKind")?;
 	match &inner.value {
 		ValueDef::Variant(inner_variant) => match inner_variant.name.as_str() {
 			"Explicit" => Ok(InvalidDisputeStatementKind::Explicit),
@@ -417,23 +391,10 @@ fn decode_validator_signature(value: &Value<u32>) -> Result<validator_app::Signa
 	match &value.value {
 		ValueDef::Composite(Composite::Unnamed(inner)) if inner.len() == 1 => decode_validator_signature(&inner[0]),
 		ValueDef::Composite(Composite::Unnamed(bytes)) if bytes.len() == 64 => {
-			let mut arr = [0u8; 64];
-			for (i, b) in bytes.iter().enumerate() {
-				match &b.value {
-					ValueDef::Primitive(Primitive::U128(v)) =>
-						arr[i] = u8::try_from(*v).map_err(|_| {
-							DynamicError::DecodeDynamicError(
-								format!("u8 at signature index {} (got {} which overflows u8)", i, v),
-								b.value.clone(),
-							)
-						})?,
-					other =>
-						return Err(DynamicError::DecodeDynamicError(
-							format!("u8 at signature index {}", i),
-							other.clone(),
-						)),
-				}
-			}
+			let decoded = decode_byte_slice(bytes)?;
+			let arr: [u8; 64] = decoded.try_into().map_err(|v: Vec<u8>| {
+				DynamicError::DecodeDynamicError(format!("64 bytes (got {})", v.len()), value.value.clone())
+			})?;
 			Ok(validator_app::Signature(arr))
 		},
 		other => Err(DynamicError::DecodeDynamicError("64-byte signature".to_string(), other.clone())),

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -23,7 +23,7 @@ use crate::{
 			ValidatorIndex,
 		},
 	},
-	types::{CoreOccupied, DisputeStatementSet, H256, OnDemandOrder, ParaInherentFields},
+	types::{CoreOccupied, DisputeStatementSet, H256, InherentData, OnDemandOrder},
 };
 use subxt::{
 	OnlineClient, PolkadotConfig,
@@ -214,7 +214,7 @@ pub(crate) fn decode_availability_cores(raw: &Value<u32>) -> Result<Vec<CoreOccu
 		.collect()
 }
 
-pub(crate) fn decode_para_inherent_fields(raw: &Composite<u32>) -> Result<ParaInherentFields, DynamicError> {
+pub(crate) fn decode_inherent_data(raw: &Composite<u32>) -> Result<InherentData, DynamicError> {
 	let data = match raw {
 		Composite::Named(fields) => find_named_field(fields, "data", raw)?,
 		Composite::Unnamed(fields) if !fields.is_empty() => &fields[0],
@@ -246,7 +246,7 @@ pub(crate) fn decode_para_inherent_fields(raw: &Composite<u32>) -> Result<ParaIn
 		.map(decode_dispute_statement_set)
 		.collect();
 
-	Ok(ParaInherentFields { bitfields: bitfields?, disputes: disputes? })
+	Ok(InherentData { bitfields: bitfields?, disputes: disputes? })
 }
 
 fn decode_availability_bitfield(value: &Value<u32>) -> Result<AvailabilityBitfield, DynamicError> {

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -16,13 +16,20 @@
 
 use crate::{
 	api::api_client::ApiClient,
-	metadata::polkadot_primitives::ValidatorIndex,
-	types::{H256, OnDemandOrder},
+	metadata::{
+		polkadot::runtime_types::polkadot_core_primitives::CandidateHash,
+		polkadot_primitives::{
+			AvailabilityBitfield, DisputeStatement, DisputeStatementSet, InvalidDisputeStatementKind,
+			ValidDisputeStatementKind, ValidatorIndex, validator_app,
+		},
+	},
+	types::{H256, OnDemandOrder, ParaInherentFields},
 };
 use subxt::{
 	OnlineClient, PolkadotConfig,
 	dynamic::{At, Value},
-	ext::scale_value::{Composite, Primitive, ValueDef},
+	ext::scale_value::{Composite, Primitive, ValueDef, Variant},
+	utils::bits::DecodedBits,
 };
 use thiserror::Error;
 
@@ -165,6 +172,228 @@ fn decode_u128_value(value: &Value<u32>) -> Result<u128, DynamicError> {
 	match &value.value {
 		ValueDef::Primitive(Primitive::U128(v)) => Ok(*v),
 		other => Err(DynamicError::DecodeDynamicError("u128".to_string(), other.clone())),
+	}
+}
+
+pub(crate) fn decode_para_inherent_fields(raw: &Composite<u32>) -> Result<ParaInherentFields, DynamicError> {
+	let data = match raw {
+		Composite::Named(fields) => fields
+			.iter()
+			.find_map(|(name, val)| if name == "data" { Some(val) } else { None })
+			.ok_or_else(|| {
+				DynamicError::DecodeDynamicError(
+					"named composite with 'data' field".to_string(),
+					ValueDef::Composite(raw.clone()),
+				)
+			})?,
+		Composite::Unnamed(fields) if !fields.is_empty() => &fields[0],
+		_ =>
+			return Err(DynamicError::DecodeDynamicError(
+				"composite with inherent data".to_string(),
+				ValueDef::Composite(raw.clone()),
+			)),
+	};
+
+	let raw_bitfields = data
+		.at("bitfields")
+		.ok_or_else(|| DynamicError::DecodeDynamicError("bitfields field".to_string(), data.value.clone()))?;
+	let bitfields_vec = decode_unnamed_composite(raw_bitfields)?;
+	let mut bitfields = Vec::with_capacity(bitfields_vec.len());
+	for raw_signed in bitfields_vec {
+		let payload = raw_signed.at("payload").ok_or_else(|| {
+			DynamicError::DecodeDynamicError("payload field in bitfield".to_string(), raw_signed.value.clone())
+		})?;
+		bitfields.push(decode_availability_bitfield(payload)?);
+	}
+
+	let raw_disputes = data
+		.at("disputes")
+		.ok_or_else(|| DynamicError::DecodeDynamicError("disputes field".to_string(), data.value.clone()))?;
+	let disputes_vec = decode_unnamed_composite(raw_disputes)?;
+	let mut disputes = Vec::with_capacity(disputes_vec.len());
+	for raw_dispute in disputes_vec {
+		disputes.push(decode_dispute_statement_set(raw_dispute)?);
+	}
+
+	Ok(ParaInherentFields { bitfields, disputes })
+}
+
+fn decode_availability_bitfield(value: &Value<u32>) -> Result<AvailabilityBitfield, DynamicError> {
+	match &value.value {
+		ValueDef::BitSequence(bits) => Ok(AvailabilityBitfield(DecodedBits::from_iter(bits.iter()))),
+		ValueDef::Composite(Composite::Unnamed(inner)) if inner.len() == 1 => decode_availability_bitfield(&inner[0]),
+		ValueDef::Composite(Composite::Unnamed(bits)) => {
+			let bools: Result<Vec<bool>, _> = bits
+				.iter()
+				.map(|b| match &b.value {
+					ValueDef::Primitive(Primitive::Bool(v)) => Ok(*v),
+					ValueDef::Primitive(Primitive::U128(v)) => Ok(*v != 0),
+					other => Err(DynamicError::DecodeDynamicError("bool in bitfield".to_string(), other.clone())),
+				})
+				.collect();
+			Ok(AvailabilityBitfield(DecodedBits::from_iter(bools?)))
+		},
+		other => Err(DynamicError::DecodeDynamicError("availability bitfield".to_string(), other.clone())),
+	}
+}
+
+fn decode_dispute_statement_set(value: &Value<u32>) -> Result<DisputeStatementSet, DynamicError> {
+	let raw_candidate_hash = value
+		.at("candidate_hash")
+		.ok_or_else(|| DynamicError::DecodeDynamicError("candidate_hash field".to_string(), value.value.clone()))?;
+	let candidate_hash = decode_candidate_hash(raw_candidate_hash)?;
+
+	let raw_session = value
+		.at("session")
+		.ok_or_else(|| DynamicError::DecodeDynamicError("session field".to_string(), value.value.clone()))?;
+	let session = decode_dynamic_u32(raw_session)?;
+
+	let raw_statements = value
+		.at("statements")
+		.ok_or_else(|| DynamicError::DecodeDynamicError("statements field".to_string(), value.value.clone()))?;
+	let statements_vec = decode_unnamed_composite(raw_statements)?;
+	let mut statements = Vec::with_capacity(statements_vec.len());
+	for raw_stmt in statements_vec {
+		let tuple = decode_unnamed_composite(raw_stmt)?;
+		if tuple.len() < 3 {
+			return Err(DynamicError::DecodeDynamicError(
+				"statement tuple with 3 elements".to_string(),
+				raw_stmt.value.clone(),
+			));
+		}
+		let statement = decode_dispute_statement(&tuple[0])?;
+		let validator_index = ValidatorIndex(decode_dynamic_u32(&tuple[1])?);
+		let signature = decode_validator_signature(&tuple[2])?;
+		statements.push((statement, validator_index, signature));
+	}
+
+	Ok(DisputeStatementSet { candidate_hash, session, statements })
+}
+
+fn decode_dispute_statement(value: &Value<u32>) -> Result<DisputeStatement, DynamicError> {
+	match &value.value {
+		ValueDef::Variant(variant) => match variant.name.as_str() {
+			"Valid" => {
+				let kind = decode_valid_dispute_statement_kind(variant)?;
+				Ok(DisputeStatement::Valid(kind))
+			},
+			"Invalid" => {
+				let kind = decode_invalid_dispute_statement_kind(variant)?;
+				Ok(DisputeStatement::Invalid(kind))
+			},
+			other => Err(DynamicError::DecodeDynamicError(
+				format!("Valid or Invalid dispute statement, got '{}'", other),
+				value.value.clone(),
+			)),
+		},
+		other => Err(DynamicError::DecodeDynamicError("variant for DisputeStatement".to_string(), other.clone())),
+	}
+}
+
+fn decode_valid_dispute_statement_kind(variant: &Variant<u32>) -> Result<ValidDisputeStatementKind, DynamicError> {
+	let inner = variant.values.values().next().ok_or_else(|| {
+		DynamicError::DecodeDynamicError(
+			"inner variant for ValidDisputeStatementKind".to_string(),
+			ValueDef::Variant(variant.clone()),
+		)
+	})?;
+	match &inner.value {
+		ValueDef::Variant(inner_variant) => match inner_variant.name.as_str() {
+			"Explicit" => Ok(ValidDisputeStatementKind::Explicit),
+			"BackingSeconded" => {
+				let hash_val = inner_variant.values.values().next().ok_or_else(|| {
+					DynamicError::DecodeDynamicError("hash in BackingSeconded".to_string(), inner.value.clone())
+				})?;
+				Ok(ValidDisputeStatementKind::BackingSeconded(decode_h256(hash_val)?))
+			},
+			"BackingValid" => {
+				let hash_val = inner_variant.values.values().next().ok_or_else(|| {
+					DynamicError::DecodeDynamicError("hash in BackingValid".to_string(), inner.value.clone())
+				})?;
+				Ok(ValidDisputeStatementKind::BackingValid(decode_h256(hash_val)?))
+			},
+			"ApprovalChecking" => Ok(ValidDisputeStatementKind::ApprovalChecking),
+			"ApprovalCheckingMultipleCandidates" => {
+				let candidates_val = inner_variant.values.values().next().ok_or_else(|| {
+					DynamicError::DecodeDynamicError(
+						"candidates in ApprovalCheckingMultipleCandidates".to_string(),
+						inner.value.clone(),
+					)
+				})?;
+				let candidates_vec = decode_unnamed_composite(candidates_val)?;
+				let mut candidates = Vec::with_capacity(candidates_vec.len());
+				for c in candidates_vec {
+					candidates.push(decode_candidate_hash(c)?);
+				}
+				Ok(ValidDisputeStatementKind::ApprovalCheckingMultipleCandidates(candidates))
+			},
+			other => Err(DynamicError::DecodeDynamicError(
+				format!("known ValidDisputeStatementKind, got '{}'", other),
+				inner.value.clone(),
+			)),
+		},
+		_ => Err(DynamicError::DecodeDynamicError(
+			"variant for ValidDisputeStatementKind".to_string(),
+			inner.value.clone(),
+		)),
+	}
+}
+
+fn decode_invalid_dispute_statement_kind(variant: &Variant<u32>) -> Result<InvalidDisputeStatementKind, DynamicError> {
+	let inner = variant.values.values().next().ok_or_else(|| {
+		DynamicError::DecodeDynamicError(
+			"inner variant for InvalidDisputeStatementKind".to_string(),
+			ValueDef::Variant(variant.clone()),
+		)
+	})?;
+	match &inner.value {
+		ValueDef::Variant(inner_variant) => match inner_variant.name.as_str() {
+			"Explicit" => Ok(InvalidDisputeStatementKind::Explicit),
+			other => Err(DynamicError::DecodeDynamicError(
+				format!("known InvalidDisputeStatementKind, got '{}'", other),
+				inner.value.clone(),
+			)),
+		},
+		_ => Err(DynamicError::DecodeDynamicError(
+			"variant for InvalidDisputeStatementKind".to_string(),
+			inner.value.clone(),
+		)),
+	}
+}
+
+fn decode_candidate_hash(value: &Value<u32>) -> Result<CandidateHash, DynamicError> {
+	match &value.value {
+		ValueDef::Composite(Composite::Unnamed(inner)) if inner.len() == 1 =>
+			Ok(CandidateHash(decode_h256(&inner[0])?)),
+		ValueDef::Composite(Composite::Named(fields)) => {
+			let hash_val = fields
+				.iter()
+				.find_map(|(name, val)| if name == "0" { Some(val) } else { None })
+				.unwrap_or(value);
+			Ok(CandidateHash(decode_h256(hash_val)?))
+		},
+		_ => Ok(CandidateHash(decode_h256(value)?)),
+	}
+}
+
+fn decode_validator_signature(value: &Value<u32>) -> Result<validator_app::Signature, DynamicError> {
+	match &value.value {
+		ValueDef::Composite(Composite::Unnamed(inner)) if inner.len() == 1 => decode_validator_signature(&inner[0]),
+		ValueDef::Composite(Composite::Unnamed(bytes)) if bytes.len() == 64 => {
+			let mut arr = [0u8; 64];
+			for (i, b) in bytes.iter().enumerate() {
+				match &b.value {
+					ValueDef::Primitive(Primitive::U128(v)) => arr[i] = *v as u8,
+					other =>
+						return Err(DynamicError::DecodeDynamicError(
+							format!("u8 at signature index {}", i),
+							other.clone(),
+						)),
+				}
+			}
+			Ok(validator_app::Signature(arr))
+		},
+		other => Err(DynamicError::DecodeDynamicError("64-byte signature".to_string(), other.clone())),
 	}
 }
 

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -57,6 +57,69 @@ pub(crate) fn decode_validator_groups(raw_groups: &Value<u32>) -> Result<Vec<Vec
 	Ok(groups)
 }
 
+pub(crate) fn decode_candidate_event(raw: &Composite<u32>) -> Result<(u32, H256, u32), DynamicError> {
+	let receipt = match raw {
+		Composite::Unnamed(fields) if !fields.is_empty() => &fields[0],
+		_ =>
+			return Err(DynamicError::DecodeDynamicError(
+				"unnamed composite with candidate receipt".to_string(),
+				ValueDef::Composite(raw.clone()),
+			)),
+	};
+
+	let descriptor = receipt
+		.at("descriptor")
+		.ok_or_else(|| DynamicError::DecodeDynamicError("descriptor field".to_string(), receipt.value.clone()))?;
+
+	let raw_para_id = descriptor
+		.at("para_id")
+		.ok_or_else(|| DynamicError::DecodeDynamicError("para_id field".to_string(), descriptor.value.clone()))?;
+	let para_id = decode_dynamic_u32(raw_para_id)?;
+
+	let raw_relay_parent = descriptor
+		.at("relay_parent")
+		.ok_or_else(|| DynamicError::DecodeDynamicError("relay_parent field".to_string(), descriptor.value.clone()))?;
+	let relay_parent = decode_h256(raw_relay_parent)?;
+
+	let core_idx = match raw {
+		Composite::Unnamed(fields) if fields.len() > 2 => decode_dynamic_u32(&fields[2])?,
+		_ =>
+			return Err(DynamicError::DecodeDynamicError(
+				"core_index field (3rd unnamed field)".to_string(),
+				ValueDef::Composite(raw.clone()),
+			)),
+	};
+
+	Ok((para_id, relay_parent, core_idx))
+}
+
+fn decode_dynamic_u32(value: &Value<u32>) -> Result<u32, DynamicError> {
+	match &value.value {
+		ValueDef::Primitive(Primitive::U128(v)) => Ok(*v as u32),
+		ValueDef::Composite(Composite::Unnamed(inner)) if !inner.is_empty() => decode_dynamic_u32(&inner[0]),
+		other => Err(DynamicError::DecodeDynamicError("u32-like value".to_string(), other.clone())),
+	}
+}
+
+fn decode_h256(value: &Value<u32>) -> Result<H256, DynamicError> {
+	match &value.value {
+		ValueDef::Composite(Composite::Unnamed(bytes)) if bytes.len() == 32 => decode_h256_from_bytes(bytes),
+		ValueDef::Composite(Composite::Unnamed(inner)) if inner.len() == 1 => decode_h256(&inner[0]),
+		other => Err(DynamicError::DecodeDynamicError("H256 (32-byte composite)".to_string(), other.clone())),
+	}
+}
+
+fn decode_h256_from_bytes(bytes: &[Value<u32>]) -> Result<H256, DynamicError> {
+	let mut arr = [0u8; 32];
+	for (i, b) in bytes.iter().enumerate() {
+		match &b.value {
+			ValueDef::Primitive(Primitive::U128(v)) => arr[i] = *v as u8,
+			other => return Err(DynamicError::DecodeDynamicError(format!("u8 at index {}", i), other.clone())),
+		}
+	}
+	Ok(H256::from(arr))
+}
+
 pub(crate) fn decode_on_demand_order(raw: &Composite<u32>) -> Result<OnDemandOrder, DynamicError> {
 	match raw {
 		Composite::Named(v) => {

--- a/essentials/src/api/dynamic.rs
+++ b/essentials/src/api/dynamic.rs
@@ -23,7 +23,7 @@ use crate::{
 			ValidDisputeStatementKind, ValidatorIndex, validator_app,
 		},
 	},
-	types::{H256, OnDemandOrder, ParaInherentFields},
+	types::{CoreOccupied, H256, OnDemandOrder, ParaInherentFields},
 };
 use subxt::{
 	OnlineClient, PolkadotConfig,
@@ -173,6 +173,27 @@ fn decode_u128_value(value: &Value<u32>) -> Result<u128, DynamicError> {
 		ValueDef::Primitive(Primitive::U128(v)) => Ok(*v),
 		other => Err(DynamicError::DecodeDynamicError("u128".to_string(), other.clone())),
 	}
+}
+
+pub(crate) fn decode_availability_cores(raw: &Value<u32>) -> Result<Vec<CoreOccupied>, DynamicError> {
+	let cores = decode_unnamed_composite(raw)?;
+	let mut result = Vec::with_capacity(cores.len());
+	for core in cores {
+		match &core.value {
+			ValueDef::Variant(variant) => match variant.name.as_str() {
+				"Free" => result.push(CoreOccupied::Free),
+				"Scheduled" => result.push(CoreOccupied::Scheduled),
+				"Occupied" => result.push(CoreOccupied::Occupied),
+				other =>
+					return Err(DynamicError::DecodeDynamicError(
+						format!("CoreState variant (Free/Scheduled/Occupied), got '{}'", other),
+						core.value.clone(),
+					)),
+			},
+			other => return Err(DynamicError::DecodeDynamicError("variant for CoreState".to_string(), other.clone())),
+		}
+	}
+	Ok(result)
 }
 
 pub(crate) fn decode_para_inherent_fields(raw: &Composite<u32>) -> Result<ParaInherentFields, DynamicError> {

--- a/essentials/src/api/executor.rs
+++ b/essentials/src/api/executor.rs
@@ -27,7 +27,6 @@ use crate::{
 			session::storage::types::queued_keys::QueuedKeys,
 		},
 		polkadot_primitives,
-		polkadot_staging_primitives::CoreState,
 	},
 	types::{
 		AccountId32, BlockNumber, ClaimQueue, CoreOccupied, H256, Header, InboundOutBoundHrmpChannels,
@@ -245,16 +244,9 @@ impl RequestExecutorBackend {
 			GetClaimQueue(hash) => ClaimQueue(client.get_claim_queue(hash).await?),
 			GetOccupiedCores(hash) => {
 				let value = client
-					.get_occupied_cores(hash)
-					.await?
-					.iter()
-					.map(|core_state| match core_state {
-						CoreState::Free => CoreOccupied::Free,
-						CoreState::Scheduled(_) => CoreOccupied::Scheduled,
-						CoreState::Occupied(_) => CoreOccupied::Occupied,
-					})
-					.collect();
-				OccupiedCores(value)
+					.fetch_dynamic_runtime_api(Some(hash), "ParachainHost", "availability_cores")
+					.await?;
+				OccupiedCores(dynamic::decode_availability_cores(&value)?)
 			},
 			GetBackingGroups(hash) => {
 				let value = fetch_dynamic_storage(client, Some(hash), "ParaScheduler", "ValidatorGroups").await?;

--- a/essentials/src/api/executor.rs
+++ b/essentials/src/api/executor.rs
@@ -29,8 +29,8 @@ use crate::{
 		polkadot_primitives,
 	},
 	types::{
-		AccountId32, BlockNumber, ClaimQueue, CoreOccupied, H256, Header, InboundOutBoundHrmpChannels,
-		ParaInherentFields, PolkadotHasher, SessionKeys, SubxtHrmpChannel, Timestamp,
+		AccountId32, BlockNumber, ClaimQueue, CoreOccupied, H256, Header, InboundOutBoundHrmpChannels, InherentData,
+		PolkadotHasher, SessionKeys, SubxtHrmpChannel, Timestamp,
 	},
 	utils::{Retry, RetryOptions},
 };
@@ -93,8 +93,8 @@ enum Response {
 	MaybeBlockHash(Option<H256>),
 	/// Block events
 	MaybeEvents(Option<subxt::events::Events<PolkadotConfig>>),
-	/// `ParaInherent` fields (bitfields and disputes).
-	ParaInherentData(ParaInherentFields),
+	/// `ParaInherent` data.
+	ParaInherentData(InherentData),
 	/// Claim queue for parachains.
 	ClaimQueue(ClaimQueue),
 	/// List of the occupied availability cores.
@@ -242,12 +242,7 @@ impl RequestExecutorBackend {
 			GetEvents(hash) => MaybeEvents(Some(client.get_events(hash).await?)),
 			ExtractParaInherent(maybe_hash) => ParaInherentData(client.extract_parainherent(maybe_hash).await?),
 			GetClaimQueue(hash) => ClaimQueue(client.get_claim_queue(hash).await?),
-			GetOccupiedCores(hash) => {
-				let value = client
-					.fetch_dynamic_runtime_api(Some(hash), "ParachainHost", "availability_cores")
-					.await?;
-				OccupiedCores(dynamic::decode_availability_cores(&value)?)
-			},
+			GetOccupiedCores(hash) => OccupiedCores(client.get_occupied_cores(hash).await?),
 			GetBackingGroups(hash) => {
 				let value = fetch_dynamic_storage(client, Some(hash), "ParaScheduler", "ValidatorGroups").await?;
 				BackingGroups(decode_validator_groups(&value)?)
@@ -424,7 +419,7 @@ impl RequestExecutor {
 		&mut self,
 		url: &str,
 		maybe_hash: Option<H256>,
-	) -> color_eyre::Result<ParaInherentFields, RequestExecutorError> {
+	) -> color_eyre::Result<InherentData, RequestExecutorError> {
 		wrap_backend_call!(self, url, ExtractParaInherent, ParaInherentData, maybe_hash)
 	}
 

--- a/essentials/src/api/executor.rs
+++ b/essentials/src/api/executor.rs
@@ -93,7 +93,7 @@ enum Response {
 	MaybeBlockHash(Option<H256>),
 	/// Block events
 	MaybeEvents(Option<subxt::events::Events<PolkadotConfig>>),
-	/// `ParaInherent` data.
+	/// `ParaInherent` fields (bitfields and disputes).
 	ParaInherentData(ParaInherentFields),
 	/// Claim queue for parachains.
 	ClaimQueue(ClaimQueue),

--- a/essentials/src/api/executor.rs
+++ b/essentials/src/api/executor.rs
@@ -30,8 +30,8 @@ use crate::{
 		polkadot_staging_primitives::CoreState,
 	},
 	types::{
-		AccountId32, BlockNumber, ClaimQueue, CoreOccupied, H256, Header, InboundOutBoundHrmpChannels, InherentData,
-		PolkadotHasher, SessionKeys, SubxtHrmpChannel, Timestamp,
+		AccountId32, BlockNumber, ClaimQueue, CoreOccupied, H256, Header, InboundOutBoundHrmpChannels,
+		ParaInherentFields, PolkadotHasher, SessionKeys, SubxtHrmpChannel, Timestamp,
 	},
 	utils::{Retry, RetryOptions},
 };
@@ -95,7 +95,7 @@ enum Response {
 	/// Block events
 	MaybeEvents(Option<subxt::events::Events<PolkadotConfig>>),
 	/// `ParaInherent` data.
-	ParaInherentData(InherentData),
+	ParaInherentData(ParaInherentFields),
 	/// Claim queue for parachains.
 	ClaimQueue(ClaimQueue),
 	/// List of the occupied availability cores.
@@ -432,7 +432,7 @@ impl RequestExecutor {
 		&mut self,
 		url: &str,
 		maybe_hash: Option<H256>,
-	) -> color_eyre::Result<InherentData, RequestExecutorError> {
+	) -> color_eyre::Result<ParaInherentFields, RequestExecutorError> {
 		wrap_backend_call!(self, url, ExtractParaInherent, ParaInherentData, maybe_hash)
 	}
 

--- a/essentials/src/api/mod.rs
+++ b/essentials/src/api/mod.rs
@@ -152,9 +152,7 @@ mod tests {
 
 		let head = subxt.get_block_head(rpc_node_url(), None).await.unwrap().unwrap();
 		let cores = subxt.get_occupied_cores(rpc_node_url(), hasher.hash_of(&head)).await;
-
-		// TODO: fix zombie net instance to return valid cores
-		assert!(cores.is_err());
+		assert!(cores.is_ok());
 	}
 
 	#[tokio::test]

--- a/essentials/src/chain_events.rs
+++ b/essentials/src/chain_events.rs
@@ -55,17 +55,19 @@ pub enum SubxtCandidateEventType {
 	/// Candidate has been timed out
 	TimedOut,
 }
-#[derive(Debug)]
-pub struct CandidateDescriptor {
-	pub relay_parent: H256,
-}
-
+/// A structure that helps to deal with the candidate events decoding some of
+/// the important fields there
 #[derive(Debug)]
 pub struct SubxtCandidateEvent {
+	/// Result of candidate receipt hashing
 	pub candidate_hash: PolkadotHash,
-	pub candidate_descriptor: CandidateDescriptor,
+	/// Relay parent from the candidate descriptor
+	pub relay_parent: H256,
+	/// The parachain id
 	pub parachain_id: u32,
+	/// The event type
 	pub event_type: SubxtCandidateEventType,
+	/// Core index
 	pub core_idx: u32,
 }
 
@@ -89,9 +91,6 @@ pub enum SubxtDisputeResult {
 	/// Dispute has been timed out
 	TimedOut,
 }
-
-// SCALE-encoded size of CandidateReceiptV2: CandidateDescriptorV2 (292 bytes) + commitments_hash (32 bytes)
-const CANDIDATE_RECEIPT_V2_SIZE: usize = 324;
 
 pub async fn decode_chain_event(
 	block_hash: PolkadotHash,
@@ -152,30 +151,6 @@ pub async fn decode_chain_event(
 	Ok(ChainEvent::RawEvent(block_hash, event))
 }
 
-fn decode_candidate_changed(
-	event: &subxt::events::EventDetails<PolkadotConfig>,
-	event_type: SubxtCandidateEventType,
-	hasher: PolkadotHasher,
-) -> Result<SubxtCandidateEvent> {
-	let (para_id, relay_parent, core_idx) = decode_candidate_event(&event.field_values()?)?;
-	let bytes = event.field_bytes();
-	if bytes.len() < CANDIDATE_RECEIPT_V2_SIZE {
-		return Err(eyre!(
-			"event field_bytes too short ({} < {}), cannot compute candidate hash",
-			bytes.len(),
-			CANDIDATE_RECEIPT_V2_SIZE
-		))
-	}
-	let candidate_hash = hasher.hash(&bytes[..CANDIDATE_RECEIPT_V2_SIZE]);
-	Ok(SubxtCandidateEvent {
-		candidate_hash,
-		candidate_descriptor: CandidateDescriptor { relay_parent },
-		parachain_id: para_id,
-		event_type,
-		core_idx,
-	})
-}
-
 fn is_specific_event<E: subxt::events::StaticEvent, C: subxt::Config>(
 	raw_event: &subxt::events::EventDetails<C>,
 ) -> bool {
@@ -204,4 +179,29 @@ fn decode_to_specific_event<E: subxt::events::StaticEvent, C: subxt::Config>(
 				)
 			})
 		})
+}
+
+// SCALE-encoded size of CandidateReceipt: CandidateDescriptor (292 bytes) + commitments_hash (32 bytes).
+// Hashing raw bytes makes us independent of receipt version since the byte layout is stable.
+const CANDIDATE_RECEIPT_SIZE: usize = 324;
+
+fn hash_candidate_receipt(bytes: &[u8], hasher: PolkadotHasher) -> Result<PolkadotHash> {
+	if bytes.len() < CANDIDATE_RECEIPT_SIZE {
+		return Err(eyre!(
+			"event field_bytes too short ({} < {}), cannot compute candidate hash",
+			bytes.len(),
+			CANDIDATE_RECEIPT_SIZE
+		))
+	}
+	Ok(hasher.hash(&bytes[..CANDIDATE_RECEIPT_SIZE]))
+}
+
+fn decode_candidate_changed(
+	event: &subxt::events::EventDetails<PolkadotConfig>,
+	event_type: SubxtCandidateEventType,
+	hasher: PolkadotHasher,
+) -> Result<SubxtCandidateEvent> {
+	let (para_id, relay_parent, core_idx) = decode_candidate_event(&event.field_values()?)?;
+	let candidate_hash = hash_candidate_receipt(event.field_bytes(), hasher)?;
+	Ok(SubxtCandidateEvent { candidate_hash, relay_parent, parachain_id: para_id, event_type, core_idx })
 }

--- a/essentials/src/chain_events.rs
+++ b/essentials/src/chain_events.rs
@@ -16,13 +16,10 @@
 //
 
 use crate::{
-	api::dynamic::decode_on_demand_order,
-	metadata::{
-		polkadot::{
-			para_inclusion::events::{CandidateBacked, CandidateIncluded, CandidateTimedOut},
-			paras_disputes::events::{DisputeConcluded, DisputeInitiated},
-		},
-		polkadot_staging_primitives::CandidateDescriptorV2,
+	api::dynamic::{decode_candidate_event, decode_on_demand_order},
+	metadata::polkadot::{
+		para_inclusion::events::{CandidateBacked, CandidateIncluded, CandidateTimedOut},
+		paras_disputes::events::{DisputeConcluded, DisputeInitiated},
 	},
 	types::{H256, Header, OnDemandOrder, PolkadotHash, PolkadotHasher},
 };
@@ -58,19 +55,18 @@ pub enum SubxtCandidateEventType {
 	/// Candidate has been timed out
 	TimedOut,
 }
-/// A structure that helps to deal with the candidate events decoding some of
-/// the important fields there
+#[derive(Debug)]
+pub struct CandidateDescriptor {
+	pub para_id: u32,
+	pub relay_parent: H256,
+}
+
 #[derive(Debug)]
 pub struct SubxtCandidateEvent {
-	/// Result of candidate receipt hashing
 	pub candidate_hash: PolkadotHash,
-	/// Full candidate receipt if needed
-	pub candidate_descriptor: CandidateDescriptorV2<PolkadotHash>,
-	/// The parachain id
+	pub candidate_descriptor: CandidateDescriptor,
 	pub parachain_id: u32,
-	/// The event type
 	pub event_type: SubxtCandidateEventType,
-	/// Core index
 	pub core_idx: u32,
 }
 
@@ -94,6 +90,8 @@ pub enum SubxtDisputeResult {
 	/// Dispute has been timed out
 	TimedOut,
 }
+
+const CANDIDATE_RECEIPT_V2_SIZE: usize = 324;
 
 pub async fn decode_chain_event(
 	block_hash: PolkadotHash,
@@ -122,36 +120,39 @@ pub async fn decode_chain_event(
 	}
 
 	if is_specific_event::<CandidateBacked, PolkadotConfig>(&event) {
-		let decoded = decode_to_specific_event::<CandidateBacked, PolkadotConfig>(&event)?;
-		return Ok(ChainEvent::CandidateChanged(Box::new(create_candidate_event(
-			decoded.0.commitments_hash,
-			decoded.0.descriptor,
-			decoded.2.0,
-			SubxtCandidateEventType::Backed,
-			hasher,
-		))))
+		let (para_id, relay_parent, core_idx) = decode_candidate_event(&event.field_values()?)?;
+		let candidate_hash = hasher.hash(&event.field_bytes()[..CANDIDATE_RECEIPT_V2_SIZE]);
+		return Ok(ChainEvent::CandidateChanged(Box::new(SubxtCandidateEvent {
+			candidate_hash,
+			candidate_descriptor: CandidateDescriptor { para_id, relay_parent },
+			parachain_id: para_id,
+			event_type: SubxtCandidateEventType::Backed,
+			core_idx,
+		})))
 	}
 
 	if is_specific_event::<CandidateIncluded, PolkadotConfig>(&event) {
-		let decoded = decode_to_specific_event::<CandidateIncluded, PolkadotConfig>(&event)?;
-		return Ok(ChainEvent::CandidateChanged(Box::new(create_candidate_event(
-			decoded.0.commitments_hash,
-			decoded.0.descriptor,
-			decoded.2.0,
-			SubxtCandidateEventType::Included,
-			hasher,
-		))))
+		let (para_id, relay_parent, core_idx) = decode_candidate_event(&event.field_values()?)?;
+		let candidate_hash = hasher.hash(&event.field_bytes()[..CANDIDATE_RECEIPT_V2_SIZE]);
+		return Ok(ChainEvent::CandidateChanged(Box::new(SubxtCandidateEvent {
+			candidate_hash,
+			candidate_descriptor: CandidateDescriptor { para_id, relay_parent },
+			parachain_id: para_id,
+			event_type: SubxtCandidateEventType::Included,
+			core_idx,
+		})))
 	}
 
 	if is_specific_event::<CandidateTimedOut, PolkadotConfig>(&event) {
-		let decoded = decode_to_specific_event::<CandidateTimedOut, PolkadotConfig>(&event)?;
-		return Ok(ChainEvent::CandidateChanged(Box::new(create_candidate_event(
-			decoded.0.commitments_hash,
-			decoded.0.descriptor,
-			decoded.2.0,
-			SubxtCandidateEventType::TimedOut,
-			hasher,
-		))))
+		let (para_id, relay_parent, core_idx) = decode_candidate_event(&event.field_values()?)?;
+		let candidate_hash = hasher.hash(&event.field_bytes()[..CANDIDATE_RECEIPT_V2_SIZE]);
+		return Ok(ChainEvent::CandidateChanged(Box::new(SubxtCandidateEvent {
+			candidate_hash,
+			candidate_descriptor: CandidateDescriptor { para_id, relay_parent },
+			parachain_id: para_id,
+			event_type: SubxtCandidateEventType::TimedOut,
+			core_idx,
+		})))
 	}
 
 	// TODO: Use `is_specific_event` as soon as shows up in types
@@ -191,16 +192,4 @@ fn decode_to_specific_event<E: subxt::events::StaticEvent, C: subxt::Config>(
 				)
 			})
 		})
-}
-
-fn create_candidate_event(
-	commitments_hash: PolkadotHash,
-	candidate_descriptor: CandidateDescriptorV2<PolkadotHash>,
-	core_idx: u32,
-	event_type: SubxtCandidateEventType,
-	hasher: PolkadotHasher,
-) -> SubxtCandidateEvent {
-	let candidate_hash = hasher.hash_of(&(&candidate_descriptor, commitments_hash));
-	let parachain_id = candidate_descriptor.para_id.0;
-	SubxtCandidateEvent { event_type, candidate_descriptor, parachain_id, candidate_hash, core_idx }
 }

--- a/essentials/src/chain_events.rs
+++ b/essentials/src/chain_events.rs
@@ -91,6 +91,7 @@ pub enum SubxtDisputeResult {
 	TimedOut,
 }
 
+// SCALE-encoded size of CandidateReceiptV2: CandidateDescriptorV2 (292 bytes) + commitments_hash (32 bytes)
 const CANDIDATE_RECEIPT_V2_SIZE: usize = 324;
 
 pub async fn decode_chain_event(
@@ -120,39 +121,21 @@ pub async fn decode_chain_event(
 	}
 
 	if is_specific_event::<CandidateBacked, PolkadotConfig>(&event) {
-		let (para_id, relay_parent, core_idx) = decode_candidate_event(&event.field_values()?)?;
-		let candidate_hash = hasher.hash(&event.field_bytes()[..CANDIDATE_RECEIPT_V2_SIZE]);
-		return Ok(ChainEvent::CandidateChanged(Box::new(SubxtCandidateEvent {
-			candidate_hash,
-			candidate_descriptor: CandidateDescriptor { para_id, relay_parent },
-			parachain_id: para_id,
-			event_type: SubxtCandidateEventType::Backed,
-			core_idx,
-		})))
+		return Ok(ChainEvent::CandidateChanged(Box::new(
+			decode_candidate_changed(&event, SubxtCandidateEventType::Backed, hasher)?,
+		)))
 	}
 
 	if is_specific_event::<CandidateIncluded, PolkadotConfig>(&event) {
-		let (para_id, relay_parent, core_idx) = decode_candidate_event(&event.field_values()?)?;
-		let candidate_hash = hasher.hash(&event.field_bytes()[..CANDIDATE_RECEIPT_V2_SIZE]);
-		return Ok(ChainEvent::CandidateChanged(Box::new(SubxtCandidateEvent {
-			candidate_hash,
-			candidate_descriptor: CandidateDescriptor { para_id, relay_parent },
-			parachain_id: para_id,
-			event_type: SubxtCandidateEventType::Included,
-			core_idx,
-		})))
+		return Ok(ChainEvent::CandidateChanged(Box::new(
+			decode_candidate_changed(&event, SubxtCandidateEventType::Included, hasher)?,
+		)))
 	}
 
 	if is_specific_event::<CandidateTimedOut, PolkadotConfig>(&event) {
-		let (para_id, relay_parent, core_idx) = decode_candidate_event(&event.field_values()?)?;
-		let candidate_hash = hasher.hash(&event.field_bytes()[..CANDIDATE_RECEIPT_V2_SIZE]);
-		return Ok(ChainEvent::CandidateChanged(Box::new(SubxtCandidateEvent {
-			candidate_hash,
-			candidate_descriptor: CandidateDescriptor { para_id, relay_parent },
-			parachain_id: para_id,
-			event_type: SubxtCandidateEventType::TimedOut,
-			core_idx,
-		})))
+		return Ok(ChainEvent::CandidateChanged(Box::new(
+			decode_candidate_changed(&event, SubxtCandidateEventType::TimedOut, hasher)?,
+		)))
 	}
 
 	// TODO: Use `is_specific_event` as soon as shows up in types
@@ -162,6 +145,30 @@ pub async fn decode_chain_event(
 	}
 
 	Ok(ChainEvent::RawEvent(block_hash, event))
+}
+
+fn decode_candidate_changed(
+	event: &subxt::events::EventDetails<PolkadotConfig>,
+	event_type: SubxtCandidateEventType,
+	hasher: PolkadotHasher,
+) -> Result<SubxtCandidateEvent> {
+	let (para_id, relay_parent, core_idx) = decode_candidate_event(&event.field_values()?)?;
+	let bytes = event.field_bytes();
+	if bytes.len() < CANDIDATE_RECEIPT_V2_SIZE {
+		return Err(eyre!(
+			"event field_bytes too short ({} < {}), cannot compute candidate hash",
+			bytes.len(),
+			CANDIDATE_RECEIPT_V2_SIZE
+		))
+	}
+	let candidate_hash = hasher.hash(&bytes[..CANDIDATE_RECEIPT_V2_SIZE]);
+	Ok(SubxtCandidateEvent {
+		candidate_hash,
+		candidate_descriptor: CandidateDescriptor { para_id, relay_parent },
+		parachain_id: para_id,
+		event_type,
+		core_idx,
+	})
 }
 
 fn is_specific_event<E: subxt::events::StaticEvent, C: subxt::Config>(

--- a/essentials/src/chain_events.rs
+++ b/essentials/src/chain_events.rs
@@ -121,21 +121,27 @@ pub async fn decode_chain_event(
 	}
 
 	if is_specific_event::<CandidateBacked, PolkadotConfig>(&event) {
-		return Ok(ChainEvent::CandidateChanged(Box::new(
-			decode_candidate_changed(&event, SubxtCandidateEventType::Backed, hasher)?,
-		)))
+		return Ok(ChainEvent::CandidateChanged(Box::new(decode_candidate_changed(
+			&event,
+			SubxtCandidateEventType::Backed,
+			hasher,
+		)?)))
 	}
 
 	if is_specific_event::<CandidateIncluded, PolkadotConfig>(&event) {
-		return Ok(ChainEvent::CandidateChanged(Box::new(
-			decode_candidate_changed(&event, SubxtCandidateEventType::Included, hasher)?,
-		)))
+		return Ok(ChainEvent::CandidateChanged(Box::new(decode_candidate_changed(
+			&event,
+			SubxtCandidateEventType::Included,
+			hasher,
+		)?)))
 	}
 
 	if is_specific_event::<CandidateTimedOut, PolkadotConfig>(&event) {
-		return Ok(ChainEvent::CandidateChanged(Box::new(
-			decode_candidate_changed(&event, SubxtCandidateEventType::TimedOut, hasher)?,
-		)))
+		return Ok(ChainEvent::CandidateChanged(Box::new(decode_candidate_changed(
+			&event,
+			SubxtCandidateEventType::TimedOut,
+			hasher,
+		)?)))
 	}
 
 	// TODO: Use `is_specific_event` as soon as shows up in types

--- a/essentials/src/chain_events.rs
+++ b/essentials/src/chain_events.rs
@@ -57,7 +57,6 @@ pub enum SubxtCandidateEventType {
 }
 #[derive(Debug)]
 pub struct CandidateDescriptor {
-	pub para_id: u32,
 	pub relay_parent: H256,
 }
 
@@ -170,7 +169,7 @@ fn decode_candidate_changed(
 	let candidate_hash = hasher.hash(&bytes[..CANDIDATE_RECEIPT_V2_SIZE]);
 	Ok(SubxtCandidateEvent {
 		candidate_hash,
-		candidate_descriptor: CandidateDescriptor { para_id, relay_parent },
+		candidate_descriptor: CandidateDescriptor { relay_parent },
 		parachain_id: para_id,
 		event_type,
 		core_idx,

--- a/essentials/src/collector/candidate_record.rs
+++ b/essentials/src/collector/candidate_record.rs
@@ -14,13 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{chain_events::SubxtDisputeResult, metadata::polkadot_staging_primitives, types::H256};
+use crate::{chain_events::SubxtDisputeResult, types::H256};
 use parity_scale_codec::{Decode, Encode};
-use serde::{
-	Deserialize, Serialize,
-	ser::{SerializeStruct, Serializer},
-};
-use std::{hash::Hash, time::Duration};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
 
 /// Tracks candidate inclusion as seen by a node(s)
 #[derive(Debug, Serialize, Deserialize, Encode, Decode, Clone)]
@@ -57,41 +54,6 @@ pub struct CandidateDisputed {
 	pub disputed: u32,
 	/// Result of a dispute
 	pub concluded: Option<DisputeResult>,
-}
-
-impl<T> Serialize for polkadot_staging_primitives::CandidateDescriptorV2<T>
-where
-	T: Hash + Serialize + Decode + Encode,
-{
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: Serializer,
-	{
-		let mut state = serializer.serialize_struct("CandidateDescriptorV2", 9)?;
-		state.serialize_field("para_id", &self.para_id.0)?;
-		state.serialize_field("relay_parent", &self.relay_parent)?;
-		state.serialize_field("persisted_validation_data_hash", &self.persisted_validation_data_hash)?;
-		state.serialize_field("pov_hash", &self.pov_hash)?;
-		state.serialize_field("erasure_root", &self.erasure_root)?;
-		state.serialize_field("para_head", &self.para_head)?;
-		state.serialize_field("validation_code_hash", &self.validation_code_hash.0)?;
-		state.end()
-	}
-}
-
-impl<T> Serialize for polkadot_staging_primitives::CandidateReceiptV2<T>
-where
-	T: Hash + Serialize + Decode + Encode,
-{
-	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-	where
-		S: Serializer,
-	{
-		let mut state = serializer.serialize_struct("CandidateReceipt", 2)?;
-		state.serialize_field("descriptor", &self.descriptor)?;
-		state.serialize_field("commitments_hash", &self.commitments_hash)?;
-		state.end()
-	}
 }
 
 /// Stores tracking data for a candidate

--- a/essentials/src/collector/mod.rs
+++ b/essentials/src/collector/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 	chain_subscription::ChainSubscriptionEvent,
 	metadata::{polkadot::runtime_types::sp_consensus_slots::Slot, polkadot_primitives::DisputeStatement},
 	storage::{RecordTime, RecordsStorageConfig, StorageEntry},
-	types::{AccountId32, ClaimQueue, H256, Header, InherentData, OnDemandOrder, PolkadotHasher, Timestamp},
+	types::{AccountId32, ClaimQueue, H256, Header, OnDemandOrder, ParaInherentFields, PolkadotHasher, Timestamp},
 };
 use candidate_record::{CandidateDisputed, CandidateInclusionRecord, CandidateRecord, DisputeResult};
 use clap::{Parser, ValueEnum};
@@ -1144,7 +1144,7 @@ impl Collector {
 			None => return Ok(default_value),
 		};
 
-		let data: InherentData = entry.into_inner()?;
+		let data: ParaInherentFields = entry.into_inner()?;
 		let statement_set = match data
 			.disputes
 			.iter()

--- a/essentials/src/collector/mod.rs
+++ b/essentials/src/collector/mod.rs
@@ -28,7 +28,7 @@ use crate::{
 	chain_subscription::ChainSubscriptionEvent,
 	metadata::{polkadot::runtime_types::sp_consensus_slots::Slot, polkadot_primitives::DisputeStatement},
 	storage::{RecordTime, RecordsStorageConfig, StorageEntry},
-	types::{AccountId32, ClaimQueue, H256, Header, OnDemandOrder, ParaInherentFields, PolkadotHasher, Timestamp},
+	types::{AccountId32, ClaimQueue, H256, Header, InherentData, OnDemandOrder, PolkadotHasher, Timestamp},
 };
 use candidate_record::{CandidateDisputed, CandidateInclusionRecord, CandidateRecord, DisputeResult};
 use clap::{Parser, ValueEnum};
@@ -923,13 +923,10 @@ impl Collector {
 				)
 				.await?;
 
-				let Some(relay_parent) = self
-					.read_or_fetch_header(change_event.candidate_descriptor.relay_parent)
-					.await?
-				else {
+				let Some(relay_parent) = self.read_or_fetch_header(change_event.relay_parent).await? else {
 					return Err(eyre!(
 						"no stored relay parent {:?} for candidate {:?}, parachain id: {}",
-						change_event.candidate_descriptor.relay_parent,
+						change_event.relay_parent,
 						change_event.candidate_hash,
 						change_event.parachain_id
 					)
@@ -938,7 +935,7 @@ impl Collector {
 
 				let relay_block_number = self.state.current_relay_chain_block_number;
 				let candidate_inclusion = CandidateInclusionRecord {
-					relay_parent: change_event.candidate_descriptor.relay_parent,
+					relay_parent: change_event.relay_parent,
 					relay_parent_number: relay_parent.number,
 					parachain_id: change_event.parachain_id,
 					backed: relay_block_number,
@@ -1151,7 +1148,7 @@ impl Collector {
 			None => return Ok(default_value),
 		};
 
-		let data: ParaInherentFields = entry.into_inner()?;
+		let data: InherentData = entry.into_inner()?;
 		let statement_set = match data
 			.disputes
 			.iter()

--- a/essentials/src/collector/mod.rs
+++ b/essentials/src/collector/mod.rs
@@ -1165,8 +1165,8 @@ impl Collector {
 			statement_set
 				.statements
 				.iter()
-				.filter(|(statement, _, _)| matches!(statement, DisputeStatement::Invalid(_)))
-				.map(|(_, idx, _)| idx.0)
+				.filter(|(statement, _)| matches!(statement, DisputeStatement::Invalid(_)))
+				.map(|(_, idx)| idx.0)
 				.collect(),
 			statement_set.session,
 		))

--- a/essentials/src/collector/mod.rs
+++ b/essentials/src/collector/mod.rs
@@ -380,11 +380,18 @@ impl Collector {
 		if let Some(hash) = new_head_hash(event, self.subscribe_mode) &&
 			let Some(block_events) = self.executor.get_events(self.endpoint.as_str(), *hash).await?
 		{
+			let mut skipped_events = 0u32;
 			for block_event in block_events.iter() {
 				match block_event {
 					Ok(event) => chain_events.push(decode_chain_event(*hash, event, self.hasher).await?),
-					Err(e) => log::warn!("Failed to decode block event at {hash:?}, skipping: {e}"),
+					Err(e) => {
+						log::warn!("Failed to decode block event at {hash:?}, skipping: {e}");
+						skipped_events += 1;
+					},
 				}
+			}
+			if skipped_events > 0 {
+				log::error!("Skipped {skipped_events} undecoded events in block {hash:?}");
 			}
 		};
 

--- a/essentials/src/collector/mod.rs
+++ b/essentials/src/collector/mod.rs
@@ -381,7 +381,10 @@ impl Collector {
 			let Some(block_events) = self.executor.get_events(self.endpoint.as_str(), *hash).await?
 		{
 			for block_event in block_events.iter() {
-				chain_events.push(decode_chain_event(*hash, block_event.unwrap(), self.hasher).await?);
+				match block_event {
+					Ok(event) => chain_events.push(decode_chain_event(*hash, event, self.hasher).await?),
+					Err(e) => log::warn!("Failed to decode block event at {hash:?}, skipping: {e}"),
+				}
 			}
 		};
 

--- a/essentials/src/types.rs
+++ b/essentials/src/types.rs
@@ -15,7 +15,10 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-use crate::metadata::{polkadot::runtime_types as subxt_runtime_types, polkadot_primitives};
+use crate::metadata::{
+	polkadot::runtime_types::{self as subxt_runtime_types, polkadot_core_primitives::CandidateHash},
+	polkadot_primitives,
+};
 use parity_scale_codec::{Decode, Encode};
 use std::collections::BTreeMap;
 use subxt::{
@@ -37,9 +40,16 @@ pub type SubxtCall = runtime::RuntimeCall;
 pub type ClaimQueue = Vec<(u32, Vec<u32>)>;
 
 #[derive(Debug, Encode, Decode)]
+pub struct DisputeStatementSet {
+	pub candidate_hash: CandidateHash,
+	pub session: u32,
+	pub statements: Vec<(polkadot_primitives::DisputeStatement, polkadot_primitives::ValidatorIndex)>,
+}
+
+#[derive(Debug, Encode, Decode)]
 pub struct ParaInherentFields {
 	pub bitfields: Vec<polkadot_primitives::AvailabilityBitfield>,
-	pub disputes: Vec<polkadot_primitives::DisputeStatementSet>,
+	pub disputes: Vec<DisputeStatementSet>,
 }
 
 /// A wrapper over subxt HRMP channel configuration

--- a/essentials/src/types.rs
+++ b/essentials/src/types.rs
@@ -40,16 +40,16 @@ pub type SubxtCall = runtime::RuntimeCall;
 pub type ClaimQueue = Vec<(u32, Vec<u32>)>;
 
 #[derive(Debug, Encode, Decode)]
+pub struct InherentData {
+	pub bitfields: Vec<polkadot_primitives::AvailabilityBitfield>,
+	pub disputes: Vec<DisputeStatementSet>,
+}
+
+#[derive(Debug, Encode, Decode)]
 pub struct DisputeStatementSet {
 	pub candidate_hash: CandidateHash,
 	pub session: u32,
 	pub statements: Vec<(polkadot_primitives::DisputeStatement, polkadot_primitives::ValidatorIndex)>,
-}
-
-#[derive(Debug, Encode, Decode)]
-pub struct ParaInherentFields {
-	pub bitfields: Vec<polkadot_primitives::AvailabilityBitfield>,
-	pub disputes: Vec<DisputeStatementSet>,
 }
 
 /// A wrapper over subxt HRMP channel configuration

--- a/essentials/src/types.rs
+++ b/essentials/src/types.rs
@@ -15,7 +15,7 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 //
 
-use crate::metadata::{polkadot::runtime_types as subxt_runtime_types, polkadot_staging_primitives};
+use crate::metadata::{polkadot::runtime_types as subxt_runtime_types, polkadot_primitives};
 use parity_scale_codec::{Decode, Encode};
 use std::collections::BTreeMap;
 use subxt::{
@@ -36,10 +36,11 @@ pub type QueuedKeys = crate::metadata::polkadot::session::storage::types::queued
 pub type SubxtCall = runtime::RuntimeCall;
 pub type ClaimQueue = Vec<(u32, Vec<u32>)>;
 
-/// The `InherentData` constructed with the subxt API.
-pub type InherentData = polkadot_staging_primitives::InherentData<
-	subxt_runtime_types::sp_runtime::generic::header::Header<::core::primitive::u32>,
->;
+#[derive(Debug, Encode, Decode)]
+pub struct ParaInherentFields {
+	pub bitfields: Vec<polkadot_primitives::AvailabilityBitfield>,
+	pub disputes: Vec<polkadot_primitives::DisputeStatementSet>,
+}
 
 /// A wrapper over subxt HRMP channel configuration
 #[derive(Debug, Clone, Default, Encode, Decode)]

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -38,7 +38,7 @@ use polkadot_introspector_essentials::{
 		},
 	},
 	storage::{RecordTime, RecordsStorageConfig, StorageEntry},
-	types::{DisputeStatementSet, H256, ParaInherentFields, PolkadotHasher, SubxtHrmpChannel},
+	types::{DisputeStatementSet, H256, InherentData, PolkadotHasher, SubxtHrmpChannel},
 	utils::RetryOptions,
 };
 use std::{collections::BTreeMap, time::Duration};
@@ -97,8 +97,8 @@ pub fn create_dispute_statement_set() -> DisputeStatementSet {
 	}
 }
 
-pub fn create_inherent_data() -> ParaInherentFields {
-	ParaInherentFields {
+pub fn create_inherent_data() -> InherentData {
+	InherentData {
 		bitfields: vec![AvailabilityBitfield(DecodedBits::from_iter([true]))],
 		disputes: vec![create_dispute_statement_set()],
 	}

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -109,7 +109,7 @@ pub fn create_dispute_statement_set() -> DisputeStatementSet {
 	}
 }
 
-pub fn create_inherent_data(_para_id: u32) -> ParaInherentFields {
+pub fn create_inherent_data() -> ParaInherentFields {
 	ParaInherentFields {
 		bitfields: vec![AvailabilityBitfield(DecodedBits::from_iter([true]))],
 		disputes: vec![create_dispute_statement_set()],

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -30,15 +30,15 @@ use polkadot_introspector_essentials::{
 			},
 		},
 		polkadot_primitives::{
-			AvailabilityBitfield, CandidateCommitments, DisputeStatement, DisputeStatementSet,
-			InvalidDisputeStatementKind, ValidDisputeStatementKind, ValidatorIndex, validator_app,
+			AvailabilityBitfield, CandidateCommitments, DisputeStatement, InvalidDisputeStatementKind,
+			ValidDisputeStatementKind, ValidatorIndex,
 		},
 		polkadot_staging_primitives::{
 			BackedCandidate, CandidateDescriptorV2, CommittedCandidateReceiptV2, InternalVersion,
 		},
 	},
 	storage::{RecordTime, RecordsStorageConfig, StorageEntry},
-	types::{H256, ParaInherentFields, PolkadotHasher, SubxtHrmpChannel},
+	types::{DisputeStatementSet, H256, ParaInherentFields, PolkadotHasher, SubxtHrmpChannel},
 	utils::RetryOptions,
 };
 use std::{collections::BTreeMap, time::Duration};
@@ -90,21 +90,9 @@ pub fn create_dispute_statement_set() -> DisputeStatementSet {
 		candidate_hash: CandidateHash(H256::random()),
 		session: 0,
 		statements: vec![
-			(
-				DisputeStatement::Valid(ValidDisputeStatementKind::Explicit),
-				ValidatorIndex(1),
-				create_validator_signature(),
-			),
-			(
-				DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
-				ValidatorIndex(2),
-				create_validator_signature(),
-			),
-			(
-				DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit),
-				ValidatorIndex(3),
-				create_validator_signature(),
-			),
+			(DisputeStatement::Valid(ValidDisputeStatementKind::Explicit), ValidatorIndex(1)),
+			(DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit), ValidatorIndex(2)),
+			(DisputeStatement::Invalid(InvalidDisputeStatementKind::Explicit), ValidatorIndex(3)),
 		],
 	}
 }
@@ -181,10 +169,6 @@ pub async fn storage_write<T: Encode>(
 			StorageEntry::new_onchain(RecordTime::with_ts(0, Duration::from_secs(0)), entry),
 		)
 		.await
-}
-
-fn create_validator_signature() -> validator_app::Signature {
-	validator_app::Signature([0; 64])
 }
 
 pub async fn create_hasher() -> PolkadotHasher {

--- a/parachain-tracer/src/test_utils.rs
+++ b/parachain-tracer/src/test_utils.rs
@@ -27,20 +27,18 @@ use polkadot_introspector_essentials::{
 				bounded_collections::bounded_vec::BoundedVec,
 				polkadot_core_primitives::CandidateHash,
 				polkadot_parachain_primitives::primitives::{HeadData, Id, ValidationCodeHash},
-				sp_runtime::generic::{digest::Digest, header::Header},
 			},
 		},
 		polkadot_primitives::{
 			AvailabilityBitfield, CandidateCommitments, DisputeStatement, DisputeStatementSet,
-			InvalidDisputeStatementKind, ValidDisputeStatementKind, ValidatorIndex, signed::UncheckedSigned,
-			validator_app,
+			InvalidDisputeStatementKind, ValidDisputeStatementKind, ValidatorIndex, validator_app,
 		},
 		polkadot_staging_primitives::{
-			BackedCandidate, CandidateDescriptorV2, CommittedCandidateReceiptV2, InherentData, InternalVersion,
+			BackedCandidate, CandidateDescriptorV2, CommittedCandidateReceiptV2, InternalVersion,
 		},
 	},
 	storage::{RecordTime, RecordsStorageConfig, StorageEntry},
-	types::{H256, PolkadotHasher, SubxtHrmpChannel},
+	types::{H256, ParaInherentFields, PolkadotHasher, SubxtHrmpChannel},
 	utils::RetryOptions,
 };
 use std::{collections::BTreeMap, time::Duration};
@@ -111,23 +109,10 @@ pub fn create_dispute_statement_set() -> DisputeStatementSet {
 	}
 }
 
-pub fn create_inherent_data(para_id: u32) -> InherentData<Header<u32>> {
-	InherentData {
-		bitfields: vec![UncheckedSigned {
-			payload: AvailabilityBitfield(DecodedBits::from_iter([true])),
-			validator_index: ValidatorIndex(1),
-			signature: create_validator_signature(),
-			__ignore: Default::default(),
-		}],
-		backed_candidates: vec![create_backed_candidate(para_id)],
+pub fn create_inherent_data(_para_id: u32) -> ParaInherentFields {
+	ParaInherentFields {
+		bitfields: vec![AvailabilityBitfield(DecodedBits::from_iter([true]))],
 		disputes: vec![create_dispute_statement_set()],
-		parent_header: Header {
-			parent_hash: H256::random(),
-			number: Default::default(),
-			state_root: Default::default(),
-			extrinsics_root: Default::default(),
-			digest: Digest { logs: Default::default() },
-		},
 	}
 }
 

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -826,7 +826,7 @@ mod test_inject_block {
 		storage_write(CollectorPrefixType::BackingGroups, first_hash, Vec::<Vec<ValidatorIndex>>::default(), &storage)
 			.await
 			.unwrap();
-		storage_write(CollectorPrefixType::InherentData, first_hash, create_inherent_data(100), &storage)
+		storage_write(CollectorPrefixType::InherentData, first_hash, create_inherent_data(), &storage)
 			.await
 			.unwrap();
 		storage_write(CollectorPrefixType::Timestamp, first_hash, 1_u64, &storage)
@@ -856,7 +856,7 @@ mod test_inject_block {
 		storage_write(CollectorPrefixType::BackingGroups, second_hash, Vec::<Vec<ValidatorIndex>>::default(), &storage)
 			.await
 			.unwrap();
-		storage_write(CollectorPrefixType::InherentData, second_hash, create_inherent_data(100), &storage)
+		storage_write(CollectorPrefixType::InherentData, second_hash, create_inherent_data(), &storage)
 			.await
 			.unwrap();
 		storage_write(CollectorPrefixType::RelevantFinalizedBlockNumber, second_hash, 40, &storage)
@@ -887,7 +887,7 @@ mod test_inject_block {
 		let mut tracker = SubxtTracker::new(100);
 
 		let block_hash = H256::random();
-		let inherent_data = create_inherent_data(100);
+		let inherent_data = create_inherent_data();
 		let backed_candidate = create_backed_candidate(100);
 		let candidate_hash = candidate_hash(&backed_candidate, hasher);
 
@@ -932,7 +932,7 @@ mod test_inject_block {
 		let mut tracker = SubxtTracker::new(100);
 
 		let block_hash = H256::random();
-		let inherent_data = create_inherent_data(100);
+		let inherent_data = create_inherent_data();
 		let backed_candidate = create_backed_candidate(100);
 		let candidate_hash = candidate_hash(&backed_candidate, hasher);
 
@@ -1011,7 +1011,7 @@ mod test_inject_block {
 		storage_write(CollectorPrefixType::BackingGroups, block_hash, Vec::<Vec<ValidatorIndex>>::default(), &storage)
 			.await
 			.unwrap();
-		storage_write(CollectorPrefixType::InherentData, block_hash, create_inherent_data(100), &storage)
+		storage_write(CollectorPrefixType::InherentData, block_hash, create_inherent_data(), &storage)
 			.await
 			.unwrap();
 		storage_write(CollectorPrefixType::Timestamp, block_hash, 1_u64, &storage)

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -27,8 +27,8 @@ use crate::{
 use log::{error, info};
 use polkadot_introspector_essentials::{
 	collector::{BackedCandidateInfo, DisputeInfo, NewHeadEvent},
-	metadata::polkadot_primitives::{AvailabilityBitfield, DisputeStatementSet, ValidatorIndex},
-	types::{BlockNumber, CoreOccupied, H256, OnDemandOrder, Timestamp},
+	metadata::polkadot_primitives::{AvailabilityBitfield, ValidatorIndex},
+	types::{BlockNumber, CoreOccupied, DisputeStatementSet, H256, OnDemandOrder, Timestamp},
 };
 use std::{collections::HashMap, default::Default, time::Duration};
 

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -22,7 +22,7 @@ use crate::{
 	stats::Stats,
 	tracker_storage::TrackerStorage,
 	types::{Block, BlockWithoutHash, DisputesTracker, ForkTracker, ParachainConsensusEvent, ParachainProgressUpdate},
-	utils::{extract_availability_bits_count, extract_inherent_fields, time_diff},
+	utils::{extract_availability_bits_count, time_diff},
 };
 use log::{error, info};
 use polkadot_introspector_essentials::{
@@ -130,22 +130,26 @@ impl SubxtTracker {
 		storage: &TrackerStorage,
 	) -> color_eyre::Result<()> {
 		if let Some(inherent) = storage.inherent_data(block_hash).await {
-			let (bitfields, disputes) = extract_inherent_fields(inherent);
 			let block_number = new_head.relay_parent_number;
 
 			self.set_relay_block(block_hash, block_number, storage).await?;
 			self.set_forks(block_hash, block_number);
 			self.set_cores(block_hash, storage).await;
-			self.set_included_candidates(block_hash, new_head.candidates_included.as_slice(), &bitfields, storage)
-				.await?;
+			self.set_included_candidates(
+				block_hash,
+				new_head.candidates_included.as_slice(),
+				&inherent.bitfields,
+				storage,
+			)
+			.await?;
 			self.set_backed_candidates(block_number, new_head.candidates_backed.as_slice())
 				.await;
 			self.set_core_assignment(block_hash, storage).await;
-			self.set_disputes(disputes.as_slice(), new_head.disputes_concluded.as_slice(), storage)
+			self.set_disputes(inherent.disputes.as_slice(), new_head.disputes_concluded.as_slice(), storage)
 				.await;
 			self.set_hrmp_channels(block_hash, storage).await?;
 			self.set_on_demand_order(block_hash, storage).await;
-			self.set_pending_availability(block_hash, &bitfields, storage).await?;
+			self.set_pending_availability(block_hash, &inherent.bitfields, storage).await?;
 			self.set_dropped_candidates();
 		} else {
 			error!("Failed to get inherent data for {:?}", block_hash);

--- a/parachain-tracer/src/tracker.rs
+++ b/parachain-tracer/src/tracker.rs
@@ -770,8 +770,8 @@ mod test_maybe_reset_state {
 mod test_inject_block {
 	use super::*;
 	use crate::test_utils::{
-		candidate_hash, create_candidate_record, create_hasher, create_inherent_data, create_para_block_info,
-		create_storage, storage_write,
+		candidate_hash, create_backed_candidate, create_candidate_record, create_hasher, create_inherent_data,
+		create_para_block_info, create_storage, storage_write,
 	};
 	use polkadot_introspector_essentials::collector::CollectorPrefixType;
 	use std::collections::BTreeMap;
@@ -888,8 +888,8 @@ mod test_inject_block {
 
 		let block_hash = H256::random();
 		let inherent_data = create_inherent_data(100);
-		let backed_candidate = inherent_data.backed_candidates.first().unwrap();
-		let candidate_hash = candidate_hash(backed_candidate, hasher);
+		let backed_candidate = create_backed_candidate(100);
+		let candidate_hash = candidate_hash(&backed_candidate, hasher);
 
 		// Inject a block
 		storage_write(
@@ -933,8 +933,8 @@ mod test_inject_block {
 
 		let block_hash = H256::random();
 		let inherent_data = create_inherent_data(100);
-		let backed_candidate = inherent_data.backed_candidates.first().unwrap();
-		let candidate_hash = candidate_hash(backed_candidate, hasher);
+		let backed_candidate = create_backed_candidate(100);
+		let candidate_hash = candidate_hash(&backed_candidate, hasher);
 
 		// Inject a block
 		storage_write(

--- a/parachain-tracer/src/tracker_storage.rs
+++ b/parachain-tracer/src/tracker_storage.rs
@@ -182,7 +182,7 @@ mod tests {
 		let hash = H256::random();
 		assert!(storage.inherent_data(hash).await.is_none());
 
-		let data = create_inherent_data(100);
+		let data = create_inherent_data();
 		api.storage()
 			.storage_write_prefixed(
 				CollectorPrefixType::InherentData,

--- a/parachain-tracer/src/tracker_storage.rs
+++ b/parachain-tracer/src/tracker_storage.rs
@@ -22,7 +22,7 @@ use polkadot_introspector_essentials::{
 		polkadot_primitives::{CoreIndex, ValidatorIndex},
 	},
 	types::{
-		AccountId32, CoreOccupied, H256, InherentData, OnDemandOrder, PolkadotHasher, SubxtHrmpChannel, Timestamp,
+		AccountId32, CoreOccupied, H256, OnDemandOrder, ParaInherentFields, PolkadotHasher, SubxtHrmpChannel, Timestamp,
 	},
 };
 use std::collections::BTreeMap;
@@ -50,7 +50,7 @@ impl TrackerStorage {
 	}
 
 	/// Reads inherent data of a relay block by its block hash
-	pub async fn inherent_data(&self, block_hash: H256) -> Option<InherentData> {
+	pub async fn inherent_data(&self, block_hash: H256) -> Option<ParaInherentFields> {
 		self.storage
 			.storage_read_prefixed(CollectorPrefixType::InherentData, block_hash)
 			.await
@@ -183,7 +183,6 @@ mod tests {
 		assert!(storage.inherent_data(hash).await.is_none());
 
 		let data = create_inherent_data(100);
-		let parent_hash = data.parent_header.parent_hash;
 		api.storage()
 			.storage_write_prefixed(
 				CollectorPrefixType::InherentData,
@@ -194,7 +193,7 @@ mod tests {
 			.unwrap();
 
 		let storage_data = storage.inherent_data(hash).await.unwrap();
-		assert_eq!(storage_data.parent_header.parent_hash, parent_hash);
+		assert!(!storage_data.disputes.is_empty());
 	}
 
 	#[tokio::test]

--- a/parachain-tracer/src/tracker_storage.rs
+++ b/parachain-tracer/src/tracker_storage.rs
@@ -22,7 +22,7 @@ use polkadot_introspector_essentials::{
 		polkadot_primitives::{CoreIndex, ValidatorIndex},
 	},
 	types::{
-		AccountId32, CoreOccupied, H256, OnDemandOrder, ParaInherentFields, PolkadotHasher, SubxtHrmpChannel, Timestamp,
+		AccountId32, CoreOccupied, H256, InherentData, OnDemandOrder, PolkadotHasher, SubxtHrmpChannel, Timestamp,
 	},
 };
 use std::collections::BTreeMap;
@@ -50,7 +50,7 @@ impl TrackerStorage {
 	}
 
 	/// Reads inherent data of a relay block by its block hash
-	pub async fn inherent_data(&self, block_hash: H256) -> Option<ParaInherentFields> {
+	pub async fn inherent_data(&self, block_hash: H256) -> Option<InherentData> {
 		self.storage
 			.storage_read_prefixed(CollectorPrefixType::InherentData, block_hash)
 			.await
@@ -178,11 +178,14 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_reads_inherent_data() {
+		use parity_scale_codec::Encode;
+
 		let (storage, api) = setup_client().await;
 		let hash = H256::random();
 		assert!(storage.inherent_data(hash).await.is_none());
 
 		let data = create_inherent_data();
+		let encoded = data.encode();
 		api.storage()
 			.storage_write_prefixed(
 				CollectorPrefixType::InherentData,
@@ -193,7 +196,7 @@ mod tests {
 			.unwrap();
 
 		let storage_data = storage.inherent_data(hash).await.unwrap();
-		assert!(!storage_data.disputes.is_empty());
+		assert_eq!(storage_data.encode(), encoded);
 	}
 
 	#[tokio::test]

--- a/parachain-tracer/src/types.rs
+++ b/parachain-tracer/src/types.rs
@@ -20,8 +20,7 @@ use crossterm::style::Stylize;
 use parity_scale_codec::{Decode, Encode};
 use polkadot_introspector_essentials::{
 	chain_events::SubxtDisputeResult,
-	metadata::polkadot_primitives::DisputeStatementSet,
-	types::{AccountId32, BlockNumber, H256, SubxtHrmpChannel, Timestamp},
+	types::{AccountId32, BlockNumber, DisputeStatementSet, H256, SubxtHrmpChannel, Timestamp},
 };
 use std::{
 	collections::HashMap,

--- a/parachain-tracer/src/utils.rs
+++ b/parachain-tracer/src/utils.rs
@@ -15,8 +15,8 @@
 // along with polkadot-introspector.  If not, see <http://www.gnu.org/licenses/>.
 
 use polkadot_introspector_essentials::{
-	metadata::polkadot_primitives::{AvailabilityBitfield, DisputeStatement, DisputeStatementSet},
-	types::{AccountId32, ParaInherentFields, Timestamp},
+	metadata::polkadot_primitives::{AvailabilityBitfield, DisputeStatement},
+	types::{AccountId32, DisputeStatementSet, ParaInherentFields, Timestamp},
 };
 use std::time::Duration;
 
@@ -150,14 +150,14 @@ pub(crate) fn extract_misbehaving_validators(
 ) -> Vec<(u32, String)> {
 	info.statements
 		.iter()
-		.filter(|(statement, _, _)| {
+		.filter(|(statement, _)| {
 			if against_valid {
 				!matches!(statement, DisputeStatement::Valid(_))
 			} else {
 				matches!(statement, DisputeStatement::Valid(_))
 			}
 		})
-		.map(|(_, idx, _)| extract_validator_address(session_keys, idx.0))
+		.map(|(_, idx)| extract_validator_address(session_keys, idx.0))
 		.collect()
 }
 
@@ -179,7 +179,7 @@ pub(crate) fn extract_votes(info: &DisputeStatementSet) -> (u32, u32) {
 	let voted_for = info
 		.statements
 		.iter()
-		.filter(|(statement, _, _)| matches!(statement, DisputeStatement::Valid(_)))
+		.filter(|(statement, _)| matches!(statement, DisputeStatement::Valid(_)))
 		.count() as u32;
 	let voted_against = info.statements.len() as u32 - voted_for;
 

--- a/parachain-tracer/src/utils.rs
+++ b/parachain-tracer/src/utils.rs
@@ -16,7 +16,7 @@
 
 use polkadot_introspector_essentials::{
 	metadata::polkadot_primitives::{AvailabilityBitfield, DisputeStatement},
-	types::{AccountId32, DisputeStatementSet, ParaInherentFields, Timestamp},
+	types::{AccountId32, DisputeStatementSet, Timestamp},
 };
 use std::time::Duration;
 
@@ -118,28 +118,6 @@ mod test_extract_validator_addresses {
 			extract_validator_addresses(Some(&keys), vec![0]),
 			vec![(0, "5C4hrfjw9DjXZTzV3MwzrrAr9P1MJhSrvWGWqi1eSuyUpnhM".to_string())]
 		);
-	}
-}
-
-pub(crate) fn extract_inherent_fields(
-	data: ParaInherentFields,
-) -> (Vec<AvailabilityBitfield>, Vec<DisputeStatementSet>) {
-	(data.bitfields, data.disputes)
-}
-
-#[cfg(test)]
-mod test_extract_inherent_fields {
-	use super::*;
-	use crate::test_utils::create_inherent_data;
-
-	#[test]
-	fn test_returns_fields() {
-		let (bitfields, disputes) = extract_inherent_fields(create_inherent_data());
-
-		println!("{:?}", matches!(bitfields.first().unwrap(), AvailabilityBitfield(_)));
-
-		assert!(matches!(bitfields.first().unwrap(), AvailabilityBitfield(_)));
-		assert!(matches!(disputes.first().unwrap(), DisputeStatementSet { .. }));
 	}
 }
 

--- a/parachain-tracer/src/utils.rs
+++ b/parachain-tracer/src/utils.rs
@@ -16,7 +16,7 @@
 
 use polkadot_introspector_essentials::{
 	metadata::polkadot_primitives::{AvailabilityBitfield, DisputeStatement, DisputeStatementSet},
-	types::{AccountId32, InherentData, Timestamp},
+	types::{AccountId32, ParaInherentFields, Timestamp},
 };
 use std::time::Duration;
 
@@ -121,14 +121,10 @@ mod test_extract_validator_addresses {
 	}
 }
 
-pub(crate) fn extract_inherent_fields(data: InherentData) -> (Vec<AvailabilityBitfield>, Vec<DisputeStatementSet>) {
-	let bitfields = data
-		.bitfields
-		.into_iter()
-		.map(|b| b.payload)
-		.collect::<Vec<AvailabilityBitfield>>();
-
-	(bitfields, data.disputes)
+pub(crate) fn extract_inherent_fields(
+	data: ParaInherentFields,
+) -> (Vec<AvailabilityBitfield>, Vec<DisputeStatementSet>) {
+	(data.bitfields, data.disputes)
 }
 
 #[cfg(test)]

--- a/parachain-tracer/src/utils.rs
+++ b/parachain-tracer/src/utils.rs
@@ -134,7 +134,7 @@ mod test_extract_inherent_fields {
 
 	#[test]
 	fn test_returns_fields() {
-		let (bitfields, disputes) = extract_inherent_fields(create_inherent_data(100));
+		let (bitfields, disputes) = extract_inherent_fields(create_inherent_data());
 
 		println!("{:?}", matches!(bitfields.first().unwrap(), AvailabilityBitfield(_)));
 


### PR DESCRIPTION
  Summary

  - Switch candidate event decoding, ParaInherent data, and availability_cores from static typed APIs to dynamic runtime value decoding. This makes us resilient to wire protocol changes across chains (e.g.
  CandidateDescriptorV2, new CoreState variants on Westend) — we only decode the fields we actually use, so minor upstream type changes no longer cause decode failures.
  - Fix silent failures and panics in dynamic decoding (missing error propagation, unwrap on empty composites, incorrect variant matching).
  - Replace generated DisputeStatementSet with our own type that omits the unused validator signature, and inline CandidateDescriptor into SubxtCandidateEvent since only relay_parent was used.