### PR TITLE
add websocket stall check with termination

### DIFF
--- a/essentials/src/chain_head_subscription.rs
+++ b/essentials/src/chain_head_subscription.rs
@@ -77,11 +77,7 @@ impl ChainHeadSubscription {
 	fn check_stall(url: &str, last_block_at: tokio::time::Instant) -> bool {
 		const BLOCK_STALL_TIMEOUT: Duration = Duration::from_secs(120);
 		if last_block_at.elapsed() > BLOCK_STALL_TIMEOUT {
-			error!(
-				"No new blocks from {} for {:?} — RPC connection appears stalled",
-				url,
-				last_block_at.elapsed()
-			);
+			error!("No new blocks from {} for {:?} — RPC connection appears stalled", url, last_block_at.elapsed());
 			return true;
 		}
 		false
@@ -157,8 +153,9 @@ impl ChainHeadSubscription {
 				}
 				_ = heartbeat_periodic.tick() => {
 					if Self::check_stall(&url, last_block_at) {
-						// Terminate only this stalled task, shutdown broadcast would kill all
-						let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
+						if let Err(e) = update_channel.send(ChainSubscriptionEvent::Termination).await {
+							info!("Failed to deliver Termination for {}: {:?}", url, e);
+						}
 						return;
 					}
 					debug!("sent heartbeat to subscribers");

--- a/essentials/src/chain_head_subscription.rs
+++ b/essentials/src/chain_head_subscription.rs
@@ -71,6 +71,22 @@ impl ChainHeadSubscription {
 		ChainHeadSubscription { urls, consumers: Vec::new(), executor }
 	}
 
+	/// Check for absence of new blocks within a timeout.
+	/// If none, consider the connection to the RPC stalled
+	/// and return `true`.
+	fn check_stall(url: &str, last_block_at: tokio::time::Instant) -> bool {
+		const BLOCK_STALL_TIMEOUT: Duration = Duration::from_secs(120);
+		if last_block_at.elapsed() > BLOCK_STALL_TIMEOUT {
+			error!(
+				"No new blocks from {} for {:?} — RPC connection appears stalled",
+				url,
+				last_block_at.elapsed()
+			);
+			return true;
+		}
+		false
+	}
+
 	// Per node
 	async fn run_per_node(
 		mut update_channel: Sender<ChainSubscriptionEvent>,
@@ -104,6 +120,7 @@ impl ChainHeadSubscription {
 
 		const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(200);
 		let mut heartbeat_periodic = interval_at(tokio::time::Instant::now() + HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL);
+		let mut last_block_at = tokio::time::Instant::now();
 
 		loop {
 			tokio::select! {
@@ -124,6 +141,8 @@ impl ChainHeadSubscription {
 						}
 					};
 
+					last_block_at = tokio::time::Instant::now();
+
 					if let Err(e) = update_channel.send(event).await {
 						info!("Event consumer has terminated: {:?}, shutting down", e);
 						return;
@@ -137,6 +156,11 @@ impl ChainHeadSubscription {
 					return;
 				}
 				_ = heartbeat_periodic.tick() => {
+					if Self::check_stall(&url, last_block_at) {
+						// Terminate only this stalled task, shutdown broadcast would kill all
+						let _ = update_channel.send(ChainSubscriptionEvent::Termination).await;
+						return;
+					}
 					debug!("sent heartbeat to subscribers");
 					if let Err(e) = update_channel.send(ChainSubscriptionEvent::Heartbeat).await {
 						info!("Event consumer has terminated: {:?}, shutting down", e);

--- a/essentials/src/chain_head_subscription.rs
+++ b/essentials/src/chain_head_subscription.rs
@@ -187,3 +187,26 @@ impl ChainHeadSubscription {
 			.collect()
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn check_stall_returns_false_when_recent() {
+		let last_block_at = tokio::time::Instant::now();
+		assert!(!ChainHeadSubscription::check_stall("wss://test:443", last_block_at));
+	}
+
+	#[test]
+	fn check_stall_returns_true_when_exceeded() {
+		let last_block_at = tokio::time::Instant::now() - Duration::from_secs(121);
+		assert!(ChainHeadSubscription::check_stall("wss://test:443", last_block_at));
+	}
+
+	#[test]
+	fn check_stall_returns_false_at_boundary() {
+		let last_block_at = tokio::time::Instant::now() - Duration::from_secs(119);
+		assert!(!ChainHeadSubscription::check_stall("wss://test:443", last_block_at));
+	}
+}


### PR DESCRIPTION
- **fix: detect stalled RPC connections and terminate gracefully**
- **test: add unit tests for check_stall**
