### PR TITLE
Update ci-unified image to `bullseye-1.93.0-2026-01-27-v202609081126`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   DOCKERFILE: scripts/ci/dockerfiles/polkadot-introspector_injected.Dockerfile
-  CI_IMAGE: paritytech/ci-unified:bullseye-1.93.0-2026-01-27-v202602020922
+  CI_IMAGE: paritytech/ci-unified:bullseye-1.93.0-2026-01-27-v202609081126
   IMAGE_NAME: paritytech/polkadot-introspector
 
 jobs:

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   DOCKERFILE: scripts/ci/dockerfiles/polkadot-introspector_injected.Dockerfile
-  CI_IMAGE: paritytech/ci-unified:bullseye-1.93.0-2026-01-27-v202602020922
+  CI_IMAGE: paritytech/ci-unified:bullseye-1.93.0-2026-01-27-v202609081126
   IMAGE_NAME: paritytech/polkadot-introspector
 
 jobs:


### PR DESCRIPTION
New bullseye ci-unified with temporary workaround for the expired `bullseye-security`

cc https://github.com/paritytech/devops/issues/5593